### PR TITLE
Add more coverage of invalid opts/args

### DIFF
--- a/test/vtquery.test.js
+++ b/test/vtquery.test.js
@@ -38,6 +38,21 @@ test('failure: item in buffers array is not an object', assert => {
   });
 });
 
+test('failure: buffer value does not exist', assert => {
+  const buffs = [
+    {
+      z: 0,
+      x: 0,
+      y: 0
+    }
+  ];
+  vtquery(buffs, [47.6117, -122.3444], {}, function(err, result) {
+    assert.ok(err);
+    assert.equal(err.message, 'item in \'tiles\' array does not include a buffer value');
+    assert.end();
+  });
+});
+
 test('failure: buffer value is null', assert => {
   const buffs = [
     {
@@ -349,6 +364,17 @@ test('failure: options.geometry does not equal an accepted value', assert => {
   vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err, result) {
     assert.ok(err);
     assert.equal(err.message, '\'geometry\' must be \'point\', \'linestring\', or \'polygon\'');
+    assert.end();
+  });
+});
+
+test('failure: options.geometry must not be empty', assert => {
+  const opts = {
+    geometry: ''
+  };
+  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err, result) {
+    assert.ok(err);
+    assert.equal(err.message, '\'geometry\' value must be a non-empty string');
     assert.end();
   });
 });


### PR DESCRIPTION
@mapsam is developing vtquery in such a way that there is extremely good coverage of error cases out of the gates. I wondered how the heck @mapsam was achieving this high of coverage so quickly and whether the `make coverage` target was working (which comes from node-cpp-skel).

I confirmed it is working and it highlighted just a few spots that were missing coverage. So, before moving on I fixed those spots in this PR.

![screen shot 2017-10-12 at 9 25 57 am](https://user-images.githubusercontent.com/20300/31507401-6165bbe2-af2f-11e7-9009-e992463f8ae7.png)
![screen shot 2017-10-12 at 9 25 48 am](https://user-images.githubusercontent.com/20300/31507402-617fe31e-af2f-11e7-80eb-2e0125b4eb09.png)
