### PR TITLE
Portable deps via mason

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,9 +8,7 @@
       # cflags (linux) and xcode (mac)
       'system_includes': [
         "-isystem <(module_root_dir)/<!(node -e \"require('nan')\")",
-        "-isystem <(module_root_dir)/mason_packages/.link/include/",
-        "-isystem <(module_root_dir)/../vtzero/include",
-        "-isystem <(module_root_dir)/../protozero/include"
+        "-isystem <(module_root_dir)/mason_packages/.link/include/"
       ],
       'compiler_checks': [
         '-Wall',
@@ -92,7 +90,7 @@
         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
         'MACOSX_DEPLOYMENT_TARGET':'10.8',
         'CLANG_CXX_LIBRARY': 'libc++',
-        'CLANG_CXX_LANGUAGE_STANDARD':'c++11',
+        'CLANG_CXX_LANGUAGE_STANDARD':'c++14',
         'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0'
       }
     }

--- a/common.gypi
+++ b/common.gypi
@@ -2,7 +2,7 @@
   'target_defaults': {
     'default_configuration': 'Release',
     'cflags_cc' : [
-      '-std=c++11',
+      '-std=c++14',
       # The assumption is that projects based on node-cpp-skel will also
       # depend on mason packages. Currently (this will change in future mason versions)
       # mason packages default to being built/linked with the CXX11_ABI=0.

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -14,6 +14,7 @@ source local.env
 
 install geometry 0.9.2
 install variant 1.1.4
-# install vtzero ...
-# install protozero ...
-# install spatial-algorithms ...
+install vtzero 556fac5
+install protozero ccf6c39
+install spatial-algorithms 2904283
+install boost 1.65.1

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,7 +3,7 @@
 set -eu
 set -o pipefail
 
-export MASON_RELEASE="${MASON_RELEASE:-v0.14.1}"
+export MASON_RELEASE="${MASON_RELEASE:-469edc8}"
 export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-4.0.1}"
 
 PLATFORM=$(uname | tr A-Z a-z)

--- a/src/vtquery.cpp
+++ b/src/vtquery.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <map>
 #include <stdexcept>
+#include <memory>
 // #include <mapbox/geometry/geometry.hpp>
 // #include <mapbox/geometry/algorithms/closest_point.hpp>
 #include <vtzero/vector_tile.hpp>


### PR DESCRIPTION
This sets up the build to pull portable versions of all deps via mason. The intention here is to ensure we can soon start testing on travis: critical since travis has memory leak and address sanitizer checking.

In addition this moves to C++14, because spatial-algorithms currently needs it: mapbox/spatial-algorithms/pull/13.

Special note: `spatial-algorithms` is packaged as a header-only library (no code is compiled). This means to use the algorithms (and have the build be able to find the symbols for them) you'll need to include the `_impl.hpp` as well as the normal header. For example:

```c++
#include <mapbox/geometry/algorithms/closest_point.hpp>
#include <mapbox/geometry/algorithms/closest_point_impl.hpp>
```

refs https://github.com/mapbox/mason/pull/486

/cc @mapsam @artemp 