### PR TITLE
Bench suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Here's an example response
 
 -   `tiles` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array).&lt;[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)>** an array of tile objects with `buffer`, `z`, `x`, and `y` values
 -   `LngLat` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array).&lt;[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>** a query point of longitude and latitude to query, `[lng, lat]`
--   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)=** 
+-   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)=**
     -   `options.radius` **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)=** the radius to query for features. If your radius is larger than
         the extent of an individual tile, include multiple nearby buffers to collect a realstic list of features (optional, default `0`)
     -   `options.results` **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)=** the number of results/features returned from the query. (optional, default `5`)
@@ -103,6 +103,27 @@ make distclean
 # Requires documentation.js to be installed globally
 npm install -g documentation
 npm run docs
+```
+
+# Benchmarks
+
+Benchmarks can be run with the bench/vtquery.bench.js script to test vtquery against common real-world fixtures (provided by mvt-fixtures). When making changes in a pull request, please provide the benchmarks from the master branch and the HEAD of your current branch.  You can control the `concurrency` and `iterations` of the benchmarks with the following command:
+
+```
+node bench/vtquery.bench.js --iterations 1000 --concurrency 5
+```
+
+And the output will show how many times the library was able to execute per second, per fixture:
+
+```
+1: 9 tiles, chicago, radius 1000 ... 191 runs/s (5240ms)
+2: 9 tiles, chicago, only points ... 3257 runs/s (307ms)
+3: mbx streets no radius ... 4049 runs/s (247ms)
+4: mbx streets 2000 radius ... 240 runs/s (4159ms)
+5: mbx streets only points ... 4673 runs/s (214ms)
+6: mbx streets only linestrings ... 286 runs/s (3499ms)
+7: mbx streets only polys ... 2801 runs/s (357ms)
+8: complex multipolygon ... 1253 runs/s (798ms)
 ```
 
 # Viz

--- a/bench/rules.js
+++ b/bench/rules.js
@@ -22,22 +22,6 @@ module.exports = [
     ]
   },
   {
-    description: '9 tiles, chicago, super large radius',
-    queryPoint: [-87.7164, 41.8705],
-    options: { radius: 10000 },
-    tiles: [
-      { z: 13, x: 2098, y: 3043, buffer: getTile('chicago', '13-2098-3043.mvt') },
-      { z: 13, x: 2099, y: 3043, buffer: getTile('chicago', '13-2099-3043.mvt') },
-      { z: 13, x: 2100, y: 3043, buffer: getTile('chicago', '13-2100-3043.mvt') },
-      { z: 13, x: 2098, y: 3044, buffer: getTile('chicago', '13-2098-3044.mvt') },
-      { z: 13, x: 2099, y: 3044, buffer: getTile('chicago', '13-2099-3044.mvt') },
-      { z: 13, x: 2100, y: 3044, buffer: getTile('chicago', '13-2100-3044.mvt') },
-      { z: 13, x: 2098, y: 3045, buffer: getTile('chicago', '13-2098-3045.mvt') },
-      { z: 13, x: 2099, y: 3045, buffer: getTile('chicago', '13-2099-3045.mvt') },
-      { z: 13, x: 2100, y: 3045, buffer: getTile('chicago', '13-2100-3045.mvt') }
-    ]
-  },
-  {
     description: '9 tiles, chicago - only points',
     queryPoint: [-87.7164, 41.8705],
     options: { radius: 1000, geometry: 'point' },

--- a/bench/rules.js
+++ b/bench/rules.js
@@ -6,7 +6,7 @@ const mvtf = require('@mapbox/mvt-fixtures');
 
 module.exports = [
   {
-    description: '9 tiles, chicago',
+    description: '9 tiles, chicago, radius 1000',
     queryPoint: [-87.7164, 41.8705],
     options: { radius: 1000 },
     tiles: [
@@ -22,7 +22,7 @@ module.exports = [
     ]
   },
   {
-    description: '9 tiles, chicago - only points',
+    description: '9 tiles, chicago, only points',
     queryPoint: [-87.7164, 41.8705],
     options: { radius: 1000, geometry: 'point' },
     tiles: [
@@ -38,7 +38,7 @@ module.exports = [
     ]
   },
   {
-    description: 'single mapbox streets tile in chicago',
+    description: 'mbx streets no radius',
     queryPoint: [-87.7371, 41.8838],
     options: { radius: 0 },
     tiles: [
@@ -46,7 +46,7 @@ module.exports = [
     ]
   },
   {
-    description: 'single mapbox streets tile in chicago',
+    description: 'mbx streets 2000 radius',
     queryPoint: [-87.7371, 41.8838],
     options: { radius: 2000 },
     tiles: [
@@ -54,7 +54,7 @@ module.exports = [
     ]
   },
   {
-    description: 'single mapbox streets tile in chicago',
+    description: 'mbx streets only points',
     queryPoint: [-87.7371, 41.8838],
     options: { radius: 2000, geometry: 'point' },
     tiles: [
@@ -62,7 +62,7 @@ module.exports = [
     ]
   },
   {
-    description: 'single mapbox streets tile in chicago',
+    description: 'mbx streets only linestrings',
     queryPoint: [-87.7371, 41.8838],
     options: { radius: 2000, geometry: 'linestring' },
     tiles: [
@@ -70,11 +70,19 @@ module.exports = [
     ]
   },
   {
-    description: 'single mapbox streets tile in chicago',
+    description: 'mbx streets only polys',
     queryPoint: [-87.7371, 41.8838],
     options: { radius: 2000, geometry: 'polygon' },
     tiles: [
       { z: 13, x: 2099, y: 3044, buffer: getTile('chicago', '13-2099-3044.mvt') }
+    ]
+  },
+  {
+    description: 'complex multipolygon',
+    queryPoint: [10.6759453345, 64.8680179376],
+    options: { radius: 4000, geometry: 'polygon' },
+    tiles: [
+      { z: 12, x: 2169, y: 1069, buffer: getTile('norway', '12-2169-1069.mvt') }
     ]
   }
 ];

--- a/bench/rules.js
+++ b/bench/rules.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const mvtf = require('@mapbox/mvt-fixtures');
+
+module.exports = [
+  {
+    description: '9 tiles, chicago',
+    queryPoint: [-87.7164, 41.8705],
+    options: { radius: 1000 },
+    tiles: [
+      { z: 13, x: 2098, y: 3043, buffer: getTile('chicago', '13-2098-3043.mvt') },
+      { z: 13, x: 2099, y: 3043, buffer: getTile('chicago', '13-2099-3043.mvt') },
+      { z: 13, x: 2100, y: 3043, buffer: getTile('chicago', '13-2100-3043.mvt') },
+      { z: 13, x: 2098, y: 3044, buffer: getTile('chicago', '13-2098-3044.mvt') },
+      { z: 13, x: 2099, y: 3044, buffer: getTile('chicago', '13-2099-3044.mvt') },
+      { z: 13, x: 2100, y: 3044, buffer: getTile('chicago', '13-2100-3044.mvt') },
+      { z: 13, x: 2098, y: 3045, buffer: getTile('chicago', '13-2098-3045.mvt') },
+      { z: 13, x: 2099, y: 3045, buffer: getTile('chicago', '13-2099-3045.mvt') },
+      { z: 13, x: 2100, y: 3045, buffer: getTile('chicago', '13-2100-3045.mvt') }
+    ]
+  },
+  {
+    description: '9 tiles, chicago, super large radius',
+    queryPoint: [-87.7164, 41.8705],
+    options: { radius: 10000 },
+    tiles: [
+      { z: 13, x: 2098, y: 3043, buffer: getTile('chicago', '13-2098-3043.mvt') },
+      { z: 13, x: 2099, y: 3043, buffer: getTile('chicago', '13-2099-3043.mvt') },
+      { z: 13, x: 2100, y: 3043, buffer: getTile('chicago', '13-2100-3043.mvt') },
+      { z: 13, x: 2098, y: 3044, buffer: getTile('chicago', '13-2098-3044.mvt') },
+      { z: 13, x: 2099, y: 3044, buffer: getTile('chicago', '13-2099-3044.mvt') },
+      { z: 13, x: 2100, y: 3044, buffer: getTile('chicago', '13-2100-3044.mvt') },
+      { z: 13, x: 2098, y: 3045, buffer: getTile('chicago', '13-2098-3045.mvt') },
+      { z: 13, x: 2099, y: 3045, buffer: getTile('chicago', '13-2099-3045.mvt') },
+      { z: 13, x: 2100, y: 3045, buffer: getTile('chicago', '13-2100-3045.mvt') }
+    ]
+  },
+  {
+    description: '9 tiles, chicago - only points',
+    queryPoint: [-87.7164, 41.8705],
+    options: { radius: 1000, geometry: 'point' },
+    tiles: [
+      { z: 13, x: 2098, y: 3043, buffer: getTile('chicago', '13-2098-3043.mvt') },
+      { z: 13, x: 2099, y: 3043, buffer: getTile('chicago', '13-2099-3043.mvt') },
+      { z: 13, x: 2100, y: 3043, buffer: getTile('chicago', '13-2100-3043.mvt') },
+      { z: 13, x: 2098, y: 3044, buffer: getTile('chicago', '13-2098-3044.mvt') },
+      { z: 13, x: 2099, y: 3044, buffer: getTile('chicago', '13-2099-3044.mvt') },
+      { z: 13, x: 2100, y: 3044, buffer: getTile('chicago', '13-2100-3044.mvt') },
+      { z: 13, x: 2098, y: 3045, buffer: getTile('chicago', '13-2098-3045.mvt') },
+      { z: 13, x: 2099, y: 3045, buffer: getTile('chicago', '13-2099-3045.mvt') },
+      { z: 13, x: 2100, y: 3045, buffer: getTile('chicago', '13-2100-3045.mvt') }
+    ]
+  },
+  {
+    description: 'single mapbox streets tile in chicago',
+    queryPoint: [-87.7371, 41.8838],
+    options: { radius: 0 },
+    tiles: [
+      { z: 13, x: 2099, y: 3044, buffer: getTile('chicago', '13-2099-3044.mvt') }
+    ]
+  },
+  {
+    description: 'single mapbox streets tile in chicago',
+    queryPoint: [-87.7371, 41.8838],
+    options: { radius: 2000 },
+    tiles: [
+      { z: 13, x: 2099, y: 3044, buffer: getTile('chicago', '13-2099-3044.mvt') }
+    ]
+  },
+  {
+    description: 'single mapbox streets tile in chicago',
+    queryPoint: [-87.7371, 41.8838],
+    options: { radius: 2000, geometry: 'point' },
+    tiles: [
+      { z: 13, x: 2099, y: 3044, buffer: getTile('chicago', '13-2099-3044.mvt') }
+    ]
+  },
+  {
+    description: 'single mapbox streets tile in chicago',
+    queryPoint: [-87.7371, 41.8838],
+    options: { radius: 2000, geometry: 'linestring' },
+    tiles: [
+      { z: 13, x: 2099, y: 3044, buffer: getTile('chicago', '13-2099-3044.mvt') }
+    ]
+  },
+  {
+    description: 'single mapbox streets tile in chicago',
+    queryPoint: [-87.7371, 41.8838],
+    options: { radius: 2000, geometry: 'polygon' },
+    tiles: [
+      { z: 13, x: 2099, y: 3044, buffer: getTile('chicago', '13-2099-3044.mvt') }
+    ]
+  }
+];
+
+function getTile(name, file) {
+  return fs.readFileSync(path.join(__dirname, '..', 'node_modules', '@mapbox', 'mvt-fixtures', 'real-world', name, file))
+}
+
+// get all tiles
+function getTiles(name) {
+  let tiles = [];
+  let dir = `./node_modules/@mapbox/mvt-fixtures/real-world/${name}`;
+  var files = fs.readdirSync(dir);
+  files.forEach(function(file) {
+    let buffer = fs.readFileSync(path.join(dir, '/', file));
+    file = file.replace('.mvt', '');
+    let zxy = file.split('-');
+    tiles.push({ buffer: buffer, z: parseInt(zxy[0]), x: parseInt(zxy[1]), y: parseInt(zxy[2]) });
+  });
+  return tiles;
+}

--- a/bench/vtquery.bench.js
+++ b/bench/vtquery.bench.js
@@ -35,7 +35,7 @@ ruleQueue.awaitAll(function(err, res) {
 
 function runRule(rule, ruleCallback) {
 
-  process.stdout.write(`\n${ruleCount}: ${rule.description}`);
+  process.stdout.write(`\n${ruleCount}: ${rule.description} ... `);
 
   let runs = 0;
   let runsQueue = Queue();
@@ -72,7 +72,7 @@ function runRule(rule, ruleCallback) {
     } else {
     // number of milliseconds per iteration
       var rate = runs/(time/1000);
-      process.stdout.write(' - ' + rate.toFixed(0) + ' runs/s (' + time + 'ms)');
+      process.stdout.write(rate.toFixed(0) + ' runs/s (' + time + 'ms)');
     }
 
     // There may be instances when you want to assert some performance metric

--- a/bench/vtquery.bench.js
+++ b/bench/vtquery.bench.js
@@ -16,82 +16,77 @@ process.env.UV_THREADPOOL_SIZE = argv.concurrency;
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
-const d3_queue = require('d3-queue');
+const Queue = require('d3-queue').queue;
 const mvtf = require('@mapbox/mvt-fixtures');
 const vtquery = require('../lib/index.js');
-const mapnik = require('mapnik');
-const queue = d3_queue.queue();
-let runs = 0;
+const rules = require('./rules');
+let ruleCount = 1;
 
-// let tiles = getTiles('bangkok');
-let tiles = [{buffer: fs.readFileSync('./mapbox-streets-v7-13-2098-3042.vector.pbf'), z: 13, x: 2098, y: 3042}];
-
-function run(cb) {
-  // let vt = new mapnik.VectorTile(13, 2098, 3042);
-  //
-  // vt.addData(tiles[0].buffer, function(err, vectorTile) {
-  //   if (err) {
-  //     return cb(err);
-  //   }
-  //   vt.query(-87.7799, 41.9513, {tolerance: 2000}, function(err, results) {
-  //     if (err) {
-  //       return cb(err);
-  //     }
-  //     ++runs;
-  //     return cb();
-  //   });
-  // });
-
-  vtquery(tiles, [-87.7799, 41.9513], {radius: 2000}, function(err, result) {
-    if (err) {
-      return cb(err);
-    }
-    ++runs;
-    return cb();
-  });
-}
-
-// Start monitoring time before async work begins within the defer iterator below.
-// AsyncWorkers will kick off actual work before the defer iterator is finished,
-// and we want to make sure we capture the time of the work of that initial cycle.
-var time = +(new Date());
-
-for (var i = 0; i < argv.iterations; i++) {
-    queue.defer(run);
-}
-
-queue.awaitAll(function(error) {
-  if (error) throw error;
-  if (runs != argv.iterations) {
-    throw new Error(`Error: did not run as expected - ${runs} != ${argv.iterations}`);
-  }
-  // check rate
-  time = +(new Date()) - time;
-
-  if (time == 0) {
-    console.log("Warning: ms timer not high enough resolution to reliably track rate. Try more iterations");
-  } else {
-  // number of milliseconds per iteration
-    var rate = runs/(time/1000);
-    console.log('Benchmark speed: ' + rate.toFixed(0) + ' runs/s (runs:' + runs + ' ms:' + time + ' )');
-  }
-
-  console.log("Benchmark iterations:",argv.iterations,"concurrency:",argv.concurrency)
-
-  // There may be instances when you want to assert some performance metric
-  //assert.equal(rate > 1000, true, 'speed not at least 1000/second ( rate was ' + rate + ' runs/s )');
-
+// run each rule synchronously
+const ruleQueue = Queue(1);
+rules.forEach(function(rule) {
+  ruleQueue.defer(runRule, rule);
 });
 
-function getTiles(name) {
-  let tiles = [];
-  let dir = `./node_modules/@mapbox/mvt-fixtures/real-world/${name}`;
-  var files = fs.readdirSync(dir);
-  files.forEach(function(file) {
-    let buffer = fs.readFileSync(path.join(dir, '/', file));
-    file = file.replace('.mvt', '');
-    let zxy = file.split('-');
-    tiles.push({ buffer: buffer, z: parseInt(zxy[0]), x: parseInt(zxy[1]), y: parseInt(zxy[2]) });
+ruleQueue.awaitAll(function(err, res) {
+  if (err) throw err;
+  log('Done with all rules.');
+});
+
+function runRule(rule, ruleCallback) {
+
+  log(`\n${ruleCount}: ${rule.description}`);
+  log(`${JSON.stringify(rule.options)}`);
+
+  let runs = 0;
+  let runsQueue = Queue();
+
+  function run(cb) {
+    vtquery(rule.tiles, rule.queryPoint, rule.options, function(err, result) {
+      if (err) {
+        return cb(err);
+      }
+      ++runs;
+      return cb();
+    });
+  }
+
+  // Start monitoring time before async work begins within the defer iterator below.
+  // AsyncWorkers will kick off actual work before the defer iterator is finished,
+  // and we want to make sure we capture the time of the work of that initial cycle.
+  var time = +(new Date());
+
+  for (var i = 0; i < argv.iterations; i++) {
+    runsQueue.defer(run);
+  }
+
+  runsQueue.awaitAll(function(error) {
+    if (error) throw error;
+    if (runs != argv.iterations) {
+      throw new Error(`Error: did not run as expected - ${runs} != ${argv.iterations}`);
+    }
+    // check rate
+    time = +(new Date()) - time;
+
+    if (time == 0) {
+      console.log("Warning: ms timer not high enough resolution to reliably track rate. Try more iterations");
+    } else {
+    // number of milliseconds per iteration
+      var rate = runs/(time/1000);
+      log('Results: \n- ' + rate.toFixed(0) + ' runs/s (runs:' + runs + ' ms:' + time + ' )');
+    }
+
+    // There may be instances when you want to assert some performance metric
+    //assert.equal(rate > 1000, true, 'speed not at least 1000/second ( rate was ' + rate + ' runs/s )');
+    ++ruleCount;
+    return ruleCallback();
   });
-  return tiles;
+}
+
+function log(message) {
+  if (argv.output && argv.output === 'json') {
+    // handle JSON output
+  } else {
+    console.log(message);
+  }
 }

--- a/bench/vtquery.bench.js
+++ b/bench/vtquery.bench.js
@@ -30,13 +30,12 @@ rules.forEach(function(rule) {
 
 ruleQueue.awaitAll(function(err, res) {
   if (err) throw err;
-  log('Done with all rules.');
+  process.stdout.write('\n');
 });
 
 function runRule(rule, ruleCallback) {
 
-  log(`\n${ruleCount}: ${rule.description}`);
-  log(`${JSON.stringify(rule.options)}`);
+  process.stdout.write(`\n${ruleCount}: ${rule.description}`);
 
   let runs = 0;
   let runsQueue = Queue();
@@ -73,7 +72,7 @@ function runRule(rule, ruleCallback) {
     } else {
     // number of milliseconds per iteration
       var rate = runs/(time/1000);
-      log('Results: \n- ' + rate.toFixed(0) + ' runs/s (runs:' + runs + ' ms:' + time + ' )');
+      process.stdout.write(' - ' + rate.toFixed(0) + ' runs/s (' + time + 'ms)');
     }
 
     // There may be instances when you want to assert some performance metric

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "devDependencies": {
     "@mapbox/mvt-fixtures": "3.0.0-beta6",
     "d3-queue": "^3.0.7",
-    "mapnik": "^3.6.2",
     "minimist": "^1.2.0",
     "tape": "^4.5.1"
   },


### PR DESCRIPTION
Actually building out a regular benchmark suite for us to use. The plan being to run vtquery against a common set of fixtures against the current build - allowing us to rebuild at different git commits and compare (presumably a branch against master, in most cases). 

Output currently looks simple but I'd like to build a possible "markdown table" output so we can copy and paste into PRs.

```
1: 9 tiles, chicago
{"radius":1000}
Results: 
- 245 runs/s (runs:1000 ms:4089 )

2: 9 tiles, chicago, super large radius
{"radius":10000}
Results: 
- 15 runs/s (runs:1000 ms:67011 )

3: 9 tiles, chicago - only points
{"radius":1000,"geometry":"point"}
Results: 
- 3021 runs/s (runs:1000 ms:331 )

4: single mapbox streets tile in chicago
{"radius":0}
Results: 
- 3984 runs/s (runs:1000 ms:251 )

5: single mapbox streets tile in chicago
{"radius":2000}
Results: 
- 230 runs/s (runs:1000 ms:4341 )

6: single mapbox streets tile in chicago
{"radius":2000,"geometry":"point"}
Results: 
- 4444 runs/s (runs:1000 ms:225 )

7: single mapbox streets tile in chicago
{"radius":2000,"geometry":"linestring"}
Results: 
- 278 runs/s (runs:1000 ms:3597 )

8: single mapbox streets tile in chicago
{"radius":2000,"geometry":"polygon"}
Results: 
- 2632 runs/s (runs:1000 ms:380 )
```

Example table output:

**benchmarks**|branch-name|master
---|---|---
9 tiles, chicago `{"radius":1000}`| 245 runs/s (runs:1000 ms:4089 ) | ... runs/s (runs:1000 ms:4089 )
9 tiles, chicago, super large radius `{"radius":10000}`| 15 runs/s (runs:1000 ms:67011 ) | ... runs/s (runs:1000 ms:67011 )
9 tiles, chicago - only points `{"radius":1000,"geometry":"point"}`| 3021 runs/s (runs:1000 ms:331 ) | ... runs/s (runs:1000 ms:331 )
single mapbox streets tile in chicago `{"radius":0}`| 3984 runs/s (runs:1000 ms:251 ) | ... runs/s (runs:1000 ms:251 )
single mapbox streets tile in chicago `{"radius":2000}`| 230 runs/s (runs:1000 ms:4341 ) | ... runs/s (runs:1000 ms:4341 )
single mapbox streets tile in chicago `{"radius":2000,"geometry":"point"}`| 4444 runs/s (runs:1000 ms:225 ) | ... runs/s (runs:1000 ms:225 )
single mapbox streets tile in chicago `{"radius":2000,"geometry":"linestring"}`| 278 runs/s (runs:1000 ms:3597 ) | ... runs/s (runs:1000 ms:3597 )
single mapbox streets tile in chicago `{"radius":2000,"geometry":"polygon"}`| 2632 runs/s (runs:1000 ms:380 ) | ... runs/s (runs:1000 ms:380 )

Thoughts @mapbox/core-tech? How would you like to see these numbers? Right now the benchmarks are based on a whole-complete-run of vtquery, so we're not doing anything around "how long does sorting take" (which will require #14-ish to be resolved first).