### PR TITLE
Fix closest_point results

### DIFF
--- a/src/geometry_processors.hpp
+++ b/src/geometry_processors.hpp
@@ -13,7 +13,7 @@ struct point_processor {
     }
 
     void points_point(vtzero::point const& point) const {
-        mpoint_.emplace_back(point.x, 4096.0 - point.y);
+        mpoint_.emplace_back(point.x, point.y);
     }
 
     void points_end() const {
@@ -32,7 +32,7 @@ struct linestring_processor {
     }
 
     void linestring_point(vtzero::point const& point) const {
-        mline_.back().emplace_back(point.x, 4096.0 - point.y);
+        mline_.back().emplace_back(point.x, point.y);
     }
 
     void linestring_end() const noexcept {
@@ -49,7 +49,7 @@ struct polygon_processor {
     }
 
     void ring_point(vtzero::point const& point) {
-        ring_.emplace_back(point.x, 4096.0 - point.y);
+        ring_.emplace_back(point.x, point.y);
     }
 
     void ring_end(bool is_outer) {

--- a/src/vtquery.cpp
+++ b/src/vtquery.cpp
@@ -250,7 +250,7 @@ struct Worker : Nan::AsyncWorker {
 
                         // convert x/y into lng/lat point
                         // TODO(sam) use geometry.hpp points instead of custom pairs
-                        std::pair<double, double> ll = utils::convert_vt_to_ll(extent, tile_obj.z, tile_obj.x, tile_obj.y, cp_info.x, (extent - cp_info.y));
+                        std::pair<double, double> ll = utils::convert_vt_to_ll(extent, tile_obj.z, tile_obj.x, tile_obj.y, cp_info.x, (cp_info.y));
                         mapbox::geometry::point<double> feature_lnglat{ll.first, ll.second};
                         auto meters = utils::distance_in_meters(query_lnglat, feature_lnglat);
 


### PR DESCRIPTION
We were flipping y coordinates before passing into closest_point, which I believe reversed the winding order and resulted in some borked results (see #28). This resolves that, but will also be fixed later once #25 is integrated.

<img width="536" alt="screen shot 2017-10-26 at 11 58 07 am" src="https://user-images.githubusercontent.com/1943001/32071719-f5f48d36-ba44-11e7-9edd-e3e5ba93789b.png">


cc @flippmoke @artemp @springmeyer 