### PR TITLE
options.numResults

### DIFF
--- a/src/vtquery.cpp
+++ b/src/vtquery.cpp
@@ -268,8 +268,6 @@ struct Worker : Nan::AsyncWorker {
             // sort features based on distance
             std::sort(results_.begin(), results_.end(), [](const ResultObject& a, const ResultObject& b) { return a.distance < b.distance; });
 
-            // TODO(sam) create new results vector (from results_) of length specific to num_results option
-
         } catch (const std::exception& e) {
             SetErrorMessage(e.what());
         }
@@ -284,6 +282,10 @@ struct Worker : Nan::AsyncWorker {
     // - Finally, you call the user's callback with your results
     void HandleOKCallback() override {
         Nan::HandleScope scope;
+
+        // number of results to loop through
+        QueryData const& data = *query_data_;
+        std::uint32_t num_results = data.num_results;
 
         v8::Local<v8::Object> results_object = Nan::New<v8::Object>();
         v8::Local<v8::Array> features_array = Nan::New<v8::Array>();
@@ -325,6 +327,9 @@ struct Worker : Nan::AsyncWorker {
             // add feature to features array
             features_array->Set(features_size, feature_obj);
             features_size++;
+            if (features_size >= num_results) {
+              break;
+            }
         }
 
         results_object->Set(Nan::New("features").ToLocalChecked(), features_array);

--- a/test/vtquery.test.js
+++ b/test/vtquery.test.js
@@ -409,6 +409,28 @@ test('options - defaults: success', assert => {
   assert.end();
 });
 
+test('options - radius: all results within radius', assert => {
+  const buffer = fs.readFileSync('./mapbox-streets-v7-13-2098-3042.vector.pbf');
+  const ll = [-87.7914, 41.9458]; // direct hit
+  vtquery([{buffer: buffer, z: 13, x: 2098, y: 3042}], ll, { numResults: 100, radius: 1000 }, function(err, result) {
+    assert.ifError(err);
+    result.features.forEach(function(feature) {
+      assert.ok(feature.properties.tilequery.distance <= 1000, 'less than radius');
+    });
+    assert.end();
+  });
+});
+
+test('options - numResults: successfully limits results', assert => {
+  const buffer = fs.readFileSync('./mapbox-streets-v7-13-2098-3042.vector.pbf');
+  const ll = [-87.7914, 41.9458]; // direct hit
+  vtquery([{buffer: buffer, z: 13, x: 2098, y: 3042}], ll, { numResults: 1, radius: 1000 }, function(err, result) {
+    assert.ifError(err);
+    assert.equal(result.features.length, 1, 'expected length');
+    assert.end();
+  });
+});
+
 test('options - layers: successfully returns only requested layers', assert => {
   const buffer = fs.readFileSync('./mapbox-streets-v7-13-2098-3042.vector.pbf');
   const ll = [-87.7914, 41.9458]; // direct hit
@@ -426,7 +448,7 @@ test('options - geometry: successfully returns only points', assert => {
   const ll = [-87.7914, 41.9458]; // direct hit
   vtquery([{buffer: buffer, z: 13, x: 2098, y: 3042}], ll, {radius: 2000, geometry: 'point'}, function(err, result) {
     assert.ifError(err);
-    assert.equal(result.features.length, 6, 'expected number of features');
+    assert.equal(result.features.length, 5, 'expected number of features');
     result.features.forEach(function(feature) {
       assert.equal(feature.properties.tilequery.geometry, 'point', 'expected original geometry');
     });
@@ -439,7 +461,7 @@ test('options - geometry: successfully returns only linestrings', assert => {
   const ll = [-87.7914, 41.9458]; // direct hit
   vtquery([{buffer: buffer, z: 13, x: 2098, y: 3042}], ll, {radius: 200, geometry: 'linestring'}, function(err, result) {
     assert.ifError(err);
-    assert.equal(result.features.length, 6, 'expected number of features');
+    assert.equal(result.features.length, 5, 'expected number of features');
     result.features.forEach(function(feature) {
       assert.equal(feature.properties.tilequery.geometry, 'linestring', 'expected original geometry');
     });
@@ -453,7 +475,7 @@ test('options - geometry: successfully returns only polygons', assert => {
   const ll = [-87.7914, 41.9458]; // direct hit
   vtquery([{buffer: buffer, z: 13, x: 2098, y: 3042}], ll, {radius: 200, geometry: 'polygon'}, function(err, result) {
     assert.ifError(err);
-    assert.equal(result.features.length, 3, 'expected number of features');
+    assert.equal(result.features.length, 5, 'expected number of features');
     result.features.forEach(function(feature) {
       assert.equal(feature.properties.tilequery.geometry, 'polygon', 'expected original geometry');
     });


### PR DESCRIPTION
Limits the number of results returned based on the `options.numResults` option. The limit is put in place within the v8 thread when iterating through the ResultObjects vector to avoid copying the needed necessary results into a new vector, but perhaps there's a more efficient way of doing this?

cc @flippmoke 