### PR TITLE
non-copyable ResultObjects

### DIFF
--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -70,4 +70,3 @@ if [[ $dirty ]]; then
 else
     exit 0
 fi
-

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,7 +4,7 @@ set -eu
 set -o pipefail
 
 export MASON_RELEASE="${MASON_RELEASE:-469edc8}"
-export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-4.0.1}"
+export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-5.0.0}"
 
 PLATFORM=$(uname | tr A-Z a-z)
 if [[ ${PLATFORM} == 'darwin' ]]; then

--- a/src/geometry_processors.hpp
+++ b/src/geometry_processors.hpp
@@ -42,7 +42,8 @@ struct linestring_processor {
 
 struct polygon_processor {
     polygon_processor(mapbox::geometry::multi_polygon<std::int64_t>& mpoly)
-        : mpoly_(mpoly) {}
+        : mpoly_(mpoly),
+          ring_() {}
 
     void ring_begin(std::uint32_t count) {
         ring_.reserve(count);

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -89,7 +89,7 @@ mapbox::geometry::point<double> convert_vt_to_ll(std::uint32_t extent,
     double size = ex * z2;
     double x0 = ex * x;
     double y0 = ex * y;
-    double y2 = 180.0 - (cp_info.y + y0) * 360.0 / size;
+    double y2 = 180.0 - (static_case<double>(cp_info.y) + y0) * 360.0 / size;
     double x1 = (static_cast<double>(cp_info.x) + x0) * 360.0 / size - 180.0;
     double y1 = 360.0 / M_PI * std::atan(std::exp(y2 * M_PI / 180.0)) - 90.0;
     return mapbox::geometry::point<double> {x1, y1};

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -79,13 +79,11 @@ mapbox::geometry::point<std::int64_t> create_query_point(double lng,
 /*
   Create a geometry.hpp point from vector tile coordinates
 */
-using alg = mapbox::geometry::algorithms::closest_point_info<std::int64_t>;
-
 mapbox::geometry::point<double> convert_vt_to_ll(std::uint32_t extent,
                                                  std::uint32_t z,
                                                  std::uint32_t x,
                                                  std::uint32_t y,
-                                                 alg::closest_point_info cp_info) {
+                                                 mapbox::geometry::algorithms::closest_point_info<std::int64_t> cp_info) {
     double z2 = static_cast<double>(static_cast<std::int64_t>(1) << z);
     double ex = static_cast<double>(extent);
     double size = ex * z2;

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -2,8 +2,8 @@
 #include <cmath>
 #include <iostream>
 #include <mapbox/cheap_ruler.hpp>
-#include <mapbox/geometry/geometry.hpp>
 #include <mapbox/geometry/algorithms/closest_point.hpp>
+#include <mapbox/geometry/geometry.hpp>
 #include <mapbox/variant.hpp>
 #include <nan.h>
 
@@ -73,7 +73,7 @@ mapbox::geometry::point<std::int64_t> create_query_point(double lng,
     std::int64_t diff_tile_y = active_tile_y - origin_tile_y;
     std::int64_t query_x = origin_x - (diff_tile_x * extent);
     std::int64_t query_y = origin_y - (diff_tile_y * extent);
-    return mapbox::geometry::point<std::int64_t> {query_x, query_y};
+    return mapbox::geometry::point<std::int64_t>{query_x, query_y};
 }
 
 /*
@@ -89,10 +89,10 @@ mapbox::geometry::point<double> convert_vt_to_ll(std::uint32_t extent,
     double size = ex * z2;
     double x0 = ex * x;
     double y0 = ex * y;
-    double y2 = 180.0 - (static_case<double>(cp_info.y) + y0) * 360.0 / size;
+    double y2 = 180.0 - (static_cast<double>(cp_info.y) + y0) * 360.0 / size;
     double x1 = (static_cast<double>(cp_info.x) + x0) * 360.0 / size - 180.0;
     double y1 = 360.0 / M_PI * std::atan(std::exp(y2 * M_PI / 180.0)) - 90.0;
-    return mapbox::geometry::point<double> {x1, y1};
+    return mapbox::geometry::point<double>{x1, y1};
 }
 
 /*

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -108,4 +108,4 @@ double distance_in_meters(mapbox::geometry::point<double> const& origin_lnglat, 
     auto d = ruler.distance(origin_lnglat, feature_lnglat);
     return d;
 }
-}
+} // namespace utils

--- a/src/vtquery.cpp
+++ b/src/vtquery.cpp
@@ -30,11 +30,6 @@ const char* getGeomTypeString(int enumVal) {
 struct ResultObject {
     using properties_type = std::vector<std::pair<std::string, vtzero::property_value_view>>;
 
-    // move constructor
-    // optimized way of taking all the memory at once
-    // when you want to change ownership of the data
-    // made by default
-
     // custom constructor
     ResultObject(
         std::vector<std::pair<std::string, vtzero::property_value_view>> && props_map, // specifies an r-value completely, whatever had the memory beforehand, this now controls it
@@ -48,32 +43,10 @@ struct ResultObject {
           distance(distance0), // these are small enough that we can just copy
           original_geometry_type(geom_type) {} // these are small enough that we can just copy
 
-    // copy constructor
-    // helpful when you need to make an entirely new copy of a result object
-    // useful for duplicating data
-    // made by default
-    // ResultObject(
-    //     mapbox::geometry::point<double> const& p, // p is a reference (someone else has control of this) to a constant value
-    //     double const& distance0,
-    //     std::vector<std::pair<std::string, vtzero::property_value_view>> const& props_map, // specifies an r-value completely, whatever had the memory beforehand, this now controls it
-    //     std::string const& name,
-    //     GeomType const& geom_type)
-    //     : coordinates(p), // creating a new p value, since the original is a const reference
-    //       distance(distance0),
-    //       properties(props_map),
-    //       layer_name(name),
-    //       original_geometry_type(geom_type) {}
-
-
-
-    // assume resultobject
-    // taking an r-value of another ResultObject and "moving" it
-    // this allows us to have another result object and make a new one
-    // use the default pattern to construct it
+    // default move constructor
     ResultObject(ResultObject &&) = default;
 
-    // non-copyable object
-    // there is no way the code will ever copy
+    // non-copyable object - there is no way the code will ever copy
     ResultObject(ResultObject const&) = delete;
 
     // use the default destructor
@@ -311,11 +284,8 @@ struct Worker : Nan::AsyncWorker {
               sorted_results_.push_back(&r); // save the pointer of r
             }
 
+            // sort based on distance
             std::sort(sorted_results_.begin(), sorted_results_.end(), [](ResultObject const * a,  ResultObject const * b) { return a->distance < b->distance; });
-
-
-            // sort features based on distance
-            // std::sort(results_.begin(), results_.end(), [](const ResultObject& a, const ResultObject& b) { return a.distance < b.distance; });
 
         } catch (const std::exception& e) {
             SetErrorMessage(e.what());
@@ -324,11 +294,6 @@ struct Worker : Nan::AsyncWorker {
 
     // The HandleOKCallback() is getting called when Execute() successfully
     // completed.
-    // - In case Execute() invoked SetErrorMessage("") this function is not
-    // getting called.
-    // - You have access to Javascript v8 objects again
-    // - You have to translate from C++ member variables to Javascript v8 objects
-    // - Finally, you call the user's callback with your results
     void HandleOKCallback() override {
         Nan::HandleScope scope;
 

--- a/src/vtquery.cpp
+++ b/src/vtquery.cpp
@@ -151,8 +151,8 @@ struct Worker : Nan::AsyncWorker {
     using Base = Nan::AsyncWorker;
 
     Worker(std::unique_ptr<QueryData> query_data,
-           Nan::Callback* callback)
-        : Base(callback),
+           Nan::Callback* cb)
+        : Base(cb),
           query_data_(std::move(query_data)),
           results_(),
           sorted_results_() {}

--- a/src/vtquery.cpp
+++ b/src/vtquery.cpp
@@ -32,19 +32,19 @@ struct ResultObject {
 
     // custom constructor
     ResultObject(
-        std::vector<std::pair<std::string, vtzero::property_value_view>> && props_map, // specifies an r-value completely, whatever had the memory beforehand, this now controls it
+        std::vector<std::pair<std::string, vtzero::property_value_view>>&& props_map, // specifies an r-value completely, whatever had the memory beforehand, this now controls it
         std::string const& name,
-        mapbox::geometry::point<double> && p,
+        mapbox::geometry::point<double>&& p,
         double distance0,
         GeomType geom_type)
         : properties(std::move(props_map)),
           layer_name(name),
           coordinates(std::move(p)),
-          distance(distance0), // these are small enough that we can just copy
+          distance(distance0),                 // these are small enough that we can just copy
           original_geometry_type(geom_type) {} // these are small enough that we can just copy
 
     // default move constructor
-    ResultObject(ResultObject &&) = default;
+    ResultObject(ResultObject&&) = default;
 
     // non-copyable object - there is no way the code will ever copy
     ResultObject(ResultObject const&) = delete;
@@ -69,8 +69,8 @@ struct TileObject {
           y(y0),
           data(node::Buffer::Data(buffer), node::Buffer::Length(buffer)),
           buffer_ref() {
-            buffer_ref.Reset(buffer.As<v8::Object>());
-          }
+        buffer_ref.Reset(buffer.As<v8::Object>());
+    }
 
     // explicitly use the destructor to clean up
     // the persistent buffer ref by Reset()-ing
@@ -98,16 +98,16 @@ struct TileObject {
 
 struct QueryData {
     explicit QueryData(std::uint32_t num_tiles)
-      : tiles(),
-        layers(),
-        latitude(0.0),
-        longitude(0.0),
-        radius(0.0),
-        zoom(0),
-        num_results(5),
-        geometry_filter_type(GeomType::all) {
-          tiles.reserve(num_tiles);
-        }
+        : tiles(),
+          layers(),
+          latitude(0.0),
+          longitude(0.0),
+          radius(0.0),
+          zoom(0),
+          num_results(5),
+          geometry_filter_type(GeomType::all) {
+        tiles.reserve(num_tiles);
+    }
 
     // non-copyable
     QueryData(QueryData const&) = delete;
@@ -281,12 +281,12 @@ struct Worker : Nan::AsyncWorker {
 
             // create sort vector
             sorted_results_.reserve(results_.size());
-            for (auto & r : results_) {
-              sorted_results_.push_back(&r); // save the pointer of r
+            for (auto& r : results_) {
+                sorted_results_.push_back(&r); // save the pointer of r
             }
 
             // sort based on distance
-            std::sort(sorted_results_.begin(), sorted_results_.end(), [](ResultObject const * a,  ResultObject const * b) { return a->distance < b->distance; });
+            std::sort(sorted_results_.begin(), sorted_results_.end(), [](ResultObject const* a, ResultObject const* b) { return a->distance < b->distance; });
 
         } catch (const std::exception& e) {
             SetErrorMessage(e.what());
@@ -343,7 +343,7 @@ struct Worker : Nan::AsyncWorker {
             features_array->Set(features_size, feature_obj);
             features_size++;
             if (features_size >= num_results) {
-              break;
+                break;
             }
         }
 

--- a/src/vtquery.cpp
+++ b/src/vtquery.cpp
@@ -151,8 +151,8 @@ struct Worker : Nan::AsyncWorker {
     using Base = Nan::AsyncWorker;
 
     Worker(std::unique_ptr<QueryData> query_data,
-           Nan::Callback* callback)
-        : Base(callback),
+           Nan::Callback* cb)
+        : Base(cb),
           query_data_(std::move(query_data)),
           results_(),
           sorted_results_() {}
@@ -354,7 +354,7 @@ struct Worker : Nan::AsyncWorker {
             Nan::Null(), results_object};
 
         // Static cast done here to avoid 'cppcoreguidelines-pro-bounds-array-to-pointer-decay' warning with clang-tidy
-        callback->Call(argc, static_cast<v8::Local<v8::Value>*>(argv));
+        cb->Call(argc, static_cast<v8::Local<v8::Value>*>(argv));
     }
 
     std::unique_ptr<QueryData> query_data_;

--- a/src/vtquery.cpp
+++ b/src/vtquery.cpp
@@ -33,13 +33,13 @@ struct ResultObject {
     // custom constructor
     ResultObject(
         std::vector<std::pair<std::string, vtzero::property_value_view>> && props_map, // specifies an r-value completely, whatever had the memory beforehand, this now controls it
-        std::string const& name,
+        std::string  name,
         mapbox::geometry::point<double> && p,
         double distance0,
         GeomType geom_type)
         : properties(std::move(props_map)),
-          layer_name(name),
-          coordinates(std::move(p)),
+          layer_name(std::move(name)),
+          coordinates(p),
           distance(distance0), // these are small enough that we can just copy
           original_geometry_type(geom_type) {} // these are small enough that we can just copy
 
@@ -68,7 +68,7 @@ struct TileObject {
           x(x0),
           y(y0),
           data(node::Buffer::Data(buffer), node::Buffer::Length(buffer)),
-          buffer_ref() {
+          {
             buffer_ref.Reset(buffer.As<v8::Object>());
           }
 
@@ -98,8 +98,8 @@ struct TileObject {
 
 struct QueryData {
     explicit QueryData(std::uint32_t num_tiles)
-      : tiles(),
-        layers(),
+      : ,
+        ,
         latitude(0.0),
         longitude(0.0),
         radius(0.0),
@@ -151,11 +151,11 @@ struct Worker : Nan::AsyncWorker {
     using Base = Nan::AsyncWorker;
 
     Worker(std::unique_ptr<QueryData> query_data,
-           Nan::Callback* cb)
-        : Base(cb),
+           Nan::Callback* callback)
+        : Base(callback),
           query_data_(std::move(query_data)),
-          results_(),
-          sorted_results_() {}
+          ,
+          {}
 
     // The Execute() function is getting called when the worker starts to run.
     // - You only have access to member variables stored in this worker.
@@ -271,7 +271,7 @@ struct Worker : Nan::AsyncWorker {
                             // wherease push_back we need to create a new object in memory and move it into the vector
                             results_.emplace_back(std::move(properties_list),
                                                   layer_name,
-                                                  std::move(feature_lnglat),
+                                                  feature_lnglat,
                                                   meters,
                                                   original_geometry_type);
                         }
@@ -354,7 +354,7 @@ struct Worker : Nan::AsyncWorker {
             Nan::Null(), results_object};
 
         // Static cast done here to avoid 'cppcoreguidelines-pro-bounds-array-to-pointer-decay' warning with clang-tidy
-        cb->Call(argc, static_cast<v8::Local<v8::Value>*>(argv));
+        callback->Call(argc, static_cast<v8::Local<v8::Value>*>(argv));
     }
 
     std::unique_ptr<QueryData> query_data_;

--- a/src/vtquery.cpp
+++ b/src/vtquery.cpp
@@ -32,19 +32,19 @@ struct ResultObject {
 
     // custom constructor
     ResultObject(
-        std::vector<std::pair<std::string, vtzero::property_value_view>> && props_map, // specifies an r-value completely, whatever had the memory beforehand, this now controls it
-        std::string  name,
-        mapbox::geometry::point<double> && p,
+        std::vector<std::pair<std::string, vtzero::property_value_view>>&& props_map, // specifies an r-value completely, whatever had the memory beforehand, this now controls it
+        std::string name,
+        mapbox::geometry::point<double>&& p,
         double distance0,
         GeomType geom_type)
         : properties(std::move(props_map)),
           layer_name(std::move(name)),
           coordinates(p),
-          distance(distance0), // these are small enough that we can just copy
+          distance(distance0),                 // these are small enough that we can just copy
           original_geometry_type(geom_type) {} // these are small enough that we can just copy
 
     // default move constructor
-    ResultObject(ResultObject &&) = default;
+    ResultObject(ResultObject&&) = default;
 
     // non-copyable object - there is no way the code will ever copy
     ResultObject(ResultObject const&) = delete;
@@ -68,9 +68,9 @@ struct TileObject {
           x(x0),
           y(y0),
           data(node::Buffer::Data(buffer), node::Buffer::Length(buffer)),
-          {
-            buffer_ref.Reset(buffer.As<v8::Object>());
-          }
+    {
+        buffer_ref.Reset(buffer.As<v8::Object>());
+    }
 
     // explicitly use the destructor to clean up
     // the persistent buffer ref by Reset()-ing
@@ -98,16 +98,16 @@ struct TileObject {
 
 struct QueryData {
     explicit QueryData(std::uint32_t num_tiles)
-      : ,
-        ,
-        latitude(0.0),
-        longitude(0.0),
-        radius(0.0),
-        zoom(0),
-        num_results(5),
-        geometry_filter_type(GeomType::all) {
-          tiles.reserve(num_tiles);
-        }
+        :,
+          ,
+          latitude(0.0),
+          longitude(0.0),
+          radius(0.0),
+          zoom(0),
+          num_results(5),
+          geometry_filter_type(GeomType::all) {
+        tiles.reserve(num_tiles);
+    }
 
     // non-copyable
     QueryData(QueryData const&) = delete;
@@ -155,7 +155,7 @@ struct Worker : Nan::AsyncWorker {
         : Base(callback),
           query_data_(std::move(query_data)),
           ,
-          {}
+    {}
 
     // The Execute() function is getting called when the worker starts to run.
     // - You only have access to member variables stored in this worker.
@@ -281,12 +281,12 @@ struct Worker : Nan::AsyncWorker {
 
             // create sort vector
             sorted_results_.reserve(results_.size());
-            for (auto & r : results_) {
-              sorted_results_.push_back(&r); // save the pointer of r
+            for (auto& r : results_) {
+                sorted_results_.push_back(&r); // save the pointer of r
             }
 
             // sort based on distance
-            std::sort(sorted_results_.begin(), sorted_results_.end(), [](ResultObject const * a,  ResultObject const * b) { return a->distance < b->distance; });
+            std::sort(sorted_results_.begin(), sorted_results_.end(), [](ResultObject const* a, ResultObject const* b) { return a->distance < b->distance; });
 
         } catch (const std::exception& e) {
             SetErrorMessage(e.what());
@@ -343,7 +343,7 @@ struct Worker : Nan::AsyncWorker {
             features_array->Set(features_size, feature_obj);
             features_size++;
             if (features_size >= num_results) {
-              break;
+                break;
             }
         }
 


### PR DESCRIPTION
### Ticket reference

Working on optimizations from #30 

### What changed?

* This updates vtquery.cpp to prevent the `ResultObject` data structures from being copyable, and instead we create them in-place (via emplace_back) without copying or needing to move them. 

* This also creates a new `sorted_results_` vector which contains only references to ResultObjects, allowing the sort operation to move a lot faster without moving or reallocating entire ResultObjects. The HandleOKCallback then uses this vector to grab data when getting results ready to return to the user.

* The `results_` vector was reallocating itself over time as the vector grew beyond its available space in memory (since we can't `reserve()` it without knowing the length). Now, with the `sorted_results_` vector, we can turn `results_` into a std::deque to avoid losing references to ResultObjects.

### Benchmarks

**Before (`profiling-benchmarks` PR)**

```
1: pip: many building polygons ... 2169 runs/s (461ms)
2: pip: many building polygons, single layer ... 2481 runs/s (403ms)
3: query: many building polygons, single layer ... 514 runs/s (1945ms)
4: query: linestrings, mapbox streets roads ... 505 runs/s (1980ms)
5: query: polygons, mapbox streets buildings ... 445 runs/s (2245ms)
6: query: all things - dense single tile ... 289 runs/s (3462ms)
7: query: all things - dense nine tiles ... 35 runs/s (28245ms)
8: elevation: terrain tile nepal ... 1495 runs/s (669ms)
9: geometry: 2000 points in a single tile, no properties ... 1577 runs/s (634ms)
10: geometry: 2000 points in a single tile, with properties ... 420 runs/s (2382ms)
11: geometry: 2000 linestrings in a single tile, no properties ... 1171 runs/s (854ms)
12: geometry: 2000 linestrings in a single tile, with properties ... 398 runs/s (2513ms)
13: geometry: 2000 polygons in a single tile, no properties ... 1104 runs/s (906ms)
14: geometry: 2000 polygons in a single tile, with properties ... 486 runs/s (2058ms)
```

**Current**

```
1: pip: many building polygons ... 2004 runs/s (499ms)
2: pip: many building polygons, single layer ... 1880 runs/s (532ms)
3: query: many building polygons, single layer ... 764 runs/s (1309ms)
4: query: linestrings, mapbox streets roads ... 1605 runs/s (623ms)
5: query: polygons, mapbox streets buildings ... 810 runs/s (1235ms)
6: query: all things - dense single tile ... 497 runs/s (2012ms)
7: query: all things - dense nine tiles ... 73 runs/s (13727ms)
8: elevation: terrain tile nepal ... 2049 runs/s (488ms)
9: geometry: 2000 points in a single tile, no properties ... 2732 runs/s (366ms)
10: geometry: 2000 points in a single tile, with properties ... 996 runs/s (1004ms)
11: geometry: 2000 linestrings in a single tile, no properties ... 1799 runs/s (556ms)
12: geometry: 2000 linestrings in a single tile, with properties ... 844 runs/s (1185ms)
13: geometry: 2000 polygons in a single tile, no properties ... 1340 runs/s (746ms)
14: geometry: 2000 polygons in a single tile, with properties ... 715 runs/s (1399ms)
```

Notice 3-14 are increased quite significantly, while 1 & 2 have decreased slightly. The decrease comes from the `PIP` benchmarks that only had a single result and sorting the results vector wasn't a significant process. The sort is still insignificant, but we are creating the new `sorted_results_` vector so this is slowing it down. Making sure radius=0 does not sort with a separate code path (since it will be boolean results) will speed this up #36 #13 

cc @flippmoke @mapbox/core-tech 