### PR TITLE
Simplify geometry handling switch statement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,6 @@ matrix:
       before_script:
         - export LD_PRELOAD=${MASON_LLVM_RT_PRELOAD}
         - export ASAN_OPTIONS=fast_unwind_on_malloc=0:${ASAN_OPTIONS}
-        - export LSAN_OPTIONS=verbosity=1:log_threads=1
         - npm test
         - unset LD_PRELOAD
         # after successful tests, publish binaries if specified in commit message


### PR DESCRIPTION
Adds a suggestion from @springmeyer in #42 

Benchmarks look about the same 👍 

**HEAD**
```
1: pip: many building polygons ... 957 runs/s (1045ms)
2: pip: many building polygons, single layer ... 1027 runs/s (974ms)
3: query: many building polygons, single layer ... 920 runs/s (1087ms)
4: query: linestrings, mapbox streets roads ... 1698 runs/s (589ms)
5: query: polygons, mapbox streets buildings ... 940 runs/s (1064ms)
6: query: all things - dense single tile ... 489 runs/s (2045ms)
7: query: all things - dense nine tiles ... 65 runs/s (15446ms)
8: elevation: terrain tile nepal ... 759 runs/s (1318ms)
9: geometry: 2000 points in a single tile, no properties ... 2203 runs/s (454ms)
10: geometry: 2000 points in a single tile, with properties ... 1761 runs/s (568ms)
11: geometry: 2000 linestrings in a single tile, no properties ... 1115 runs/s (897ms)
12: geometry: 2000 linestrings in a single tile, with properties ... 959 runs/s (1043ms)
13: geometry: 2000 polygons in a single tile, no properties ... 667 runs/s (1500ms)
14: geometry: 2000 polygons in a single tile, with properties ... 248 runs/s (4026ms)
```

**master**
```
1: pip: many building polygons ... 978 runs/s (1023ms)
2: pip: many building polygons, single layer ... 1048 runs/s (954ms)
3: query: many building polygons, single layer ... 918 runs/s (1089ms)
4: query: linestrings, mapbox streets roads ... 1706 runs/s (586ms)
5: query: polygons, mapbox streets buildings ... 915 runs/s (1093ms)
6: query: all things - dense single tile ... 507 runs/s (1974ms)
7: query: all things - dense nine tiles ... 66 runs/s (15261ms)
8: elevation: terrain tile nepal ... 729 runs/s (1371ms)
9: geometry: 2000 points in a single tile, no properties ... 2137 runs/s (468ms)
10: geometry: 2000 points in a single tile, with properties ... 1704 runs/s (587ms)
11: geometry: 2000 linestrings in a single tile, no properties ... 1085 runs/s (922ms)
12: geometry: 2000 linestrings in a single tile, with properties ... 970 runs/s (1031ms)
13: geometry: 2000 polygons in a single tile, no properties ... 657 runs/s (1522ms)
14: geometry: 2000 polygons in a single tile, with properties ... 231 runs/s (4329ms)
```