### PR TITLE
No more boomerangs

### DIFF
--- a/src/util.hpp
+++ b/src/util.hpp
@@ -6,6 +6,8 @@
 #include <mapbox/geometry/geometry.hpp>
 #include <mapbox/variant.hpp>
 #include <nan.h>
+#include <vtzero/types.hpp>
+#include <vtzero/vector_tile.hpp>
 
 namespace utils {
 

--- a/src/vtquery.cpp
+++ b/src/vtquery.cpp
@@ -16,22 +16,6 @@
 #include <vtzero/types.hpp>
 #include <vtzero/vector_tile.hpp>
 
-/* deduping notes
-
-  - start by saving has_id
-  - store the ID (even if it doesn't)
-  - store extracted vector of tag pairs
-
-  - loop over the priority queue
-  - compare geometry
-  - THEN: if both have id, compare IDs
-  - compare vector of tag pairs
-    - if same length check (vector=vector)
-    -
-
-*/
-
-
 namespace VectorTileQuery {
 
 enum GeomType { point,
@@ -54,7 +38,6 @@ struct ResultObject {
     bool has_id;
     uint64_t id;
 
-    // default constructor
     ResultObject() :
         properties(),
         comparison_tags(),
@@ -66,10 +49,9 @@ struct ResultObject {
         id(0) {}
 
     ResultObject(ResultObject&&) = default;
-
-    // ResultObject(ResultObject const&) = delete;
-
-    // use the default destructor
+    ResultObject& operator=(ResultObject&&) = default;
+    ResultObject(ResultObject const&) = delete;
+    ResultObject& operator=(ResultObject const&) = delete;
     ~ResultObject() = default;
 };
 

--- a/test/vtquery.test.js
+++ b/test/vtquery.test.js
@@ -466,6 +466,7 @@ test('options - radius=0: only returns "point in polygon" results (on a building
   vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, { radius: 0, layers: ['building'] }, function(err, result) {
     assert.ifError(err);
     assert.equal(result.features.length, 1, 'only one building returned');
+    assert.equal(result.features[0].properties.height, 7, 'expected property value');
     assert.deepEqual(result.features[0].properties.tilequery, { distance: 0.0, layer: 'building', geometry: 'polygon' }, 'expected tilequery info');
     assert.end();
   });


### PR DESCRIPTION
This is a PR after pairing with @flippmoke to do the following:

* removes the vector of pointers for `ResultObject`s - instead sorting on the actual vector of result objects
* adds a `insert_result` method that is used to replace values instead of remove/add values
* reduces if/else nesting (boomerang) to simplify code

### benchmarks

Notice the bolded items in the `after` section - this seems to significantly slow down the "query" benchmarks (where radius > 0). This is likely due to the sorting of heavy objects again, rather than pointers. What do you think @flippmoke?

[before] dedup branch https://github.com/mapbox/vtquery/pull/51/commits/4479bcccfd7f15b5b5726c484dae89f228184897

1. pip: many building polygons ... 962 runs/s (1039ms)
2. pip: many building polygons, single layer ... 1050 runs/s (952ms)
3. query: many building polygons, single layer ... 923 runs/s (1083ms)
4. query: linestrings, mapbox streets roads ... 1610 runs/s (621ms)
5. query: polygons, mapbox streets buildings ... 917 runs/s (1090ms)
6. query: all things - dense single tile ... 519 runs/s (1925ms)
7. query: all things - dense nine tiles ... 65 runs/s (15348ms)
8. elevation: terrain tile nepal ... 713 runs/s (1403ms)
9. geometry: 2000 points in a single tile, no properties ... 2146 runs/s (466ms)
10. geometry: 2000 points in a single tile, with properties ... 1672 runs/s (598ms)
11. geometry: 2000 linestrings in a single tile, no properties ... 1104 runs/s (906ms)
12. geometry: 2000 linestrings in a single tile, with properties ... 918 runs/s (1089ms)
13. geometry: 2000 polygons in a single tile, no properties ... 655 runs/s (1526ms)
14. geometry: 2000 polygons in a single tile, with properties ... 201 runs/s (4979ms)

[after] https://github.com/mapbox/vtquery/commit/4db56d0842e2c7aa35ec006860bd5ae7ddd4206d

1. pip: many building polygons ... 955 runs/s (1047ms)
2. pip: many building polygons, single layer ... 1060 runs/s (943ms)
3. **query: many building polygons, single layer ... 566 runs/s (1766ms)**
4. **query: linestrings, mapbox streets roads ... 818 runs/s (1223ms)**
5. **query: polygons, mapbox streets buildings ... 594 runs/s (1683ms)**
6. **query: all things - dense single tile ... 366 runs/s (2732ms)**
7. **query: all things - dense nine tiles ... 47 runs/s (21248ms)**
8. elevation: terrain tile nepal ... 824 runs/s (1213ms)
9. geometry: 2000 points in a single tile, no properties ... 2016 runs/s (496ms)
10. geometry: 2000 points in a single tile, with properties ... 1046 runs/s (956ms)
11. geometry: 2000 linestrings in a single tile, no properties ... 1100 runs/s (909ms)
12. geometry: 2000 linestrings in a single tile, with properties ... 587 runs/s (1704ms)
13. geometry: 2000 polygons in a single tile, no properties ... 701 runs/s (1426ms)
14. geometry: 2000 polygons in a single tile, with properties ... 522 runs/s (1914ms)




