### PR TITLE
Fix sanitizer job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,7 @@ matrix:
     # Sanitizer build node v4/Debug
     - os: linux
       env: BUILDTYPE=debug TOOLSET=asan
+      sudo: required # workaround https://github.com/mapbox/node-cpp-skel/issues/93
       node_js: 4
       # Overrides `install` to set up custom asan flags
       install:


### PR DESCRIPTION
Works around mapbox/node-cpp-skel#93.

Mostly queued this up to ensure sanitizer jobs could still pass (no other problems snuck in while they were failing due to travis). Happy to see they are still green with the workaround.