### PR TITLE
test results order

### DIFF
--- a/test/vtquery.test.js
+++ b/test/vtquery.test.js
@@ -708,3 +708,18 @@ test('error: throws on invalid tile that is missing geometry type', assert => {
     assert.end();
   });
 });
+
+test('results with same exact distance return in expected order', assert => {
+  // this query returns four results, three of which are the exact same distance and different types of features
+  const buffer = fs.readFileSync(path.resolve(__dirname+'/../node_modules/@mapbox/mvt-fixtures/real-world/chicago/13-2098-3045.mvt'));
+  const ll = [-87.7964, 41.8675];
+  vtquery([{buffer: buffer, z: 13, x: 2098, y: 3045}], ll, { radius: 10, layers: ['road'] }, function(err, result) {
+    assert.equal(result.features[1].properties.type, 'turning_circle', 'is expected type');
+    assert.ok(checkClose(result.features[1].properties.tilequery.distance, 9.436356889343624, 1e-6), 'is the proper distance');
+    assert.equal(result.features[2].properties.type, 'service:driveway', 'is expected type');
+    assert.ok(checkClose(result.features[2].properties.tilequery.distance, 9.436356889343624, 1e-6), 'is the proper distance');
+    assert.equal(result.features[3].properties.type, 'pedestrian', 'is expected type');
+    assert.ok(checkClose(result.features[3].properties.tilequery.distance, 9.436356889343624, 1e-6), 'is the proper distance');
+    assert.end();
+  });
+});


### PR DESCRIPTION
This adds a test asserting on the order of results with the same distance values, ensuring they remain in the same order. Resolves #44 