### PR TITLE
use mason 0.18.0

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,7 +3,7 @@
 set -eu
 set -o pipefail
 
-export MASON_RELEASE="${MASON_RELEASE:-680c6a6}"
+export MASON_RELEASE="${MASON_RELEASE:-v0.18.0}"
 export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-5.0.0}"
 
 PLATFORM=$(uname | tr A-Z a-z)


### PR DESCRIPTION
Uses a pinned version of Mason (0.18.0) which was just released.

cc @springmeyer @flippmoke 