### PR TITLE
Enable LTO

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -37,11 +37,15 @@
         'defines': [
           'NDEBUG'
         ],
+        'cflags': ['-flto'],
+        'ldflags': ['-flto'],
         'xcode_settings': {
           'OTHER_CPLUSPLUSFLAGS!': [
             '-Os',
             '-O2'
           ],
+          'OTHER_LDFLAGS':[ '-flto' ],
+          'OTHER_CPLUSPLUSFLAGS!': [ '-flto' ],
           'GCC_OPTIMIZATION_LEVEL': '3',
           'GCC_GENERATE_DEBUGGING_SYMBOLS': 'NO',
           'DEAD_CODE_STRIPPING': 'YES',

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,6 +5,7 @@ set -o pipefail
 
 export MASON_RELEASE="${MASON_RELEASE:-v0.18.0}"
 export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-5.0.0}"
+export BINUTILS_VERSION="${BINUTILS_VERSION:-2.30}"
 
 PLATFORM=$(uname | tr A-Z a-z)
 if [[ ${PLATFORM} == 'darwin' ]]; then
@@ -63,6 +64,12 @@ function run() {
     }
 
     setup_mason $(pwd)/.mason ${MASON_RELEASE}
+
+    # install binutils for LTO on linux
+    if [[ $(uname -s) == 'Linux' ]]; then
+      $(pwd)/.mason/mason install binutils ${BINUTILS_VERSION}
+      $(pwd)/.mason/mason link binutils ${BINUTILS_VERSION}
+    fi
 
     #
     # ENV SETTINGS


### PR DESCRIPTION
This enables Link Time Optimization for the vtquery build.

Learn more about why LTO is important at https://github.com/mapbox/cpp/blob/d7b1681d650f600940652744a31fd019195e9c31/glossary.md#link-time-optimization

This will ensure that vtquery code runs as fast as possible even if we split the code into more .cpp files as part of #14.

Next steps:

 - [ ] I ported vtquery here to ensure this works, now that it does, it also needs to be backported to node-cpp-skel
 - [ ] Run basic benchmarks on linux (inside docker container) to make sure code is actually just as fast (should see no difference).

refs https://github.com/mapbox/cpp/pull/49
