### PR TITLE
[WIP] Mason js port additions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,10 @@ default: release
 
 # install deps but for now ignore our own install script
 # so that we can run it directly in either debug or release
-node_modules:
+node_modules/nan:
 	npm install --ignore-scripts
 
-mason_packages/headers: node_modules
+mason_packages/headers: node_modules/nan
 	node_modules/.bin/mason-js install
 
 mason_packages/.link/include: mason_packages/headers

--- a/Makefile
+++ b/Makefile
@@ -22,24 +22,18 @@ export WERROR ?= true
 
 default: release
 
+# install deps but for now ignore our own install script
+# so that we can run it directly in either debug or release
 node_modules:
-	# install deps but for now ignore our own install script
-	# so that we can run it directly in either debug or release
 	npm install --ignore-scripts
 
-node_modules/.bin/mason-js:
-	npm install mason-js-sdk
-
-node_modules/.bin/node-pre-gyp:
-	npm install node-pre-gyp
-
-mason_packages/headers: node_modules/.bin/mason-js
+mason_packages/headers: node_modules
 	node_modules/.bin/mason-js install
 
 mason_packages/.link/include: mason_packages/headers
 	node_modules/.bin/mason-js link
 
-build-deps: mason_packages/.link/include node_modules/.bin/node-pre-gyp node_modules
+build-deps: mason_packages/.link/include
 
 release: build-deps
 	V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,20 @@
+# This Makefile serves a few purposes:
+#
+# 1. It provides an interface to iterate quickly while developing the C++ code in src/
+# by typing `make` or `make debug`. To make iteration as fast as possible it calls out
+# directly to underlying build tools and skips running steps that appear to have already
+# been run (determined by the presence of a known file or directory). What `make` does is
+# the same as running `npm install --build-from-source` except that it is faster when
+# run a second time and may break if your build deps failed to install but their directories
+# do exist. If you hit a build error do to this, you should be able to fix it by running
+# `make distclean` and then `make` again.
+#
+# 2. It provides a few commands that call out to external scripts like `make coverage` or
+# `make tidy`. These scripts can be called directly but this Makefile provides a more uniform
+# interface to call them.
+#
+# To learn more about the build system see https://github.com/mapbox/node-cpp-skel/blob/master/docs/extended-tour.md#builds
+
 MODULE_NAME := $(shell node -e "console.log(require('./package.json').binary.module_name)")
 
 # Whether to turn compiler warnings into errors
@@ -10,17 +27,25 @@ node_modules:
 	# so that we can run it directly in either debug or release
 	npm install --ignore-scripts
 
-mason_packages:
-	mason-js install 
+node_modules/.bin/mason-js:
+	npm install mason-js-sdk
 
-mason_packages/.link: mason_packages
-	mason-js link
+node_modules/.bin/node-pre-gyp:
+	npm install node-pre-gyp
 
-release: node_modules mason_packages/.link
+mason_packages/headers: node_modules/.bin/mason-js
+	node_modules/.bin/mason-js install
+
+mason_packages/.link/include: mason_packages/headers
+	node_modules/.bin/mason-js link
+
+build-deps: mason_packages/.link/include node_modules/.bin/node-pre-gyp node_modules
+
+release: build-deps
 	V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error
 	@echo "run 'make clean' for full rebuild"
 
-debug: node_modules mason_packages/.link
+debug: mason_packages/.link/include
 	V=1 ./node_modules/.bin/node-pre-gyp configure build --error_on_warnings=$(WERROR) --loglevel=error --debug
 	@echo "run 'make clean' for full rebuild"
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "nan": "~2.5.1",
     "node-pre-gyp": "~0.6.32", 
-    "mason-js-sdk": "https://mapbox-npm.s3.amazonaws.com/package/mason-js-sdk-0.0.6-alpha-e8d7722417a180e9499b9dd7356f81501322d576.tgz"
+    "mason-js-sdk": "https://mapbox-npm.s3.amazonaws.com/package/mason-js-sdk-0.1.0-alpha1-1b5129e4b18272f1f1b07ec76f3e1288a7526606.tgz"
   },
   "bundledDependencies": [
     "node-pre-gyp"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "test": "UV_THREADPOOL_SIZE=1 tape test/*.test.js",
     "prepublishOnly": "npm ls",
-    "install": "mason-js install && node-pre-gyp install --fallback-to-build",
+    "mason": "mason-js install && mason-js link",
+    "install": "npm run mason && node-pre-gyp install --fallback-to-build",
     "docs": "documentation readme lib/index.js --section=API"
   },
   "author": "Mapbox",

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -12,18 +12,29 @@ Return `1` if there are files to be formatted, and automatically formats them.
 Returns `0` if everything looks properly formatted.
 
 '
- # Set up the environment by installing mason and clang++
- # See https://github.com/mapbox/node-cpp-skel/blob/master/docs/extended-tour.md#configuration-files
-./scripts/setup.sh --config local.env
+
+PATH_TO_FORMAT_SCRIPT="$(pwd)/mason_packages/.link/bin/clang-format"
+
+# to speed up re-runs, only re-create environment if needed
+if [[ ! -f local.env ]] || [[ ! -f ${PATH_TO_FORMAT_SCRIPT} ]]; then
+    # automatically setup environment
+    ./scripts/setup.sh --config local.env
+fi
+
+# source the environment
 source local.env
 
-# Add clang-format as a dep
-mason install clang-format ${MASON_LLVM_RELEASE}
-mason link clang-format ${MASON_LLVM_RELEASE}
+# to speed up re-runs, only install clang-format if needed
+if [[ ! -f ${PATH_TO_FORMAT_SCRIPT} ]]; then
+    # The MASON_LLVM_RELEASE variable comes from `local.env`
+    node_modules/.bin/mason-js install clang-format=${MASON_LLVM_RELEASE} --type=compiled
+    node_modules/.bin/mason-js link clang-format=${MASON_LLVM_RELEASE} --type=compiled
+    # We link the tools to make it easy to know ${PATH_TO_FORMAT_SCRIPT}
+fi
 
 # Run clang-format on all cpp and hpp files in the /src directory
 find src/ -type f -name '*.hpp' -o -name '*.cpp' \
- | xargs -I{} clang-format -i -style=file {}
+ | xargs -I{} ${PATH_TO_FORMAT_SCRIPT} -i -style=file {}
 
 # Print list of modified files
 dirty=$(git ls-files --modified src/)

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -20,24 +20,16 @@ always returns 0 even on errors.
 
 '
 
+PATH_TO_CLANG_TIDY_SCRIPT="$(pwd)/mason_packages/.link/share/run-clang-tidy.py"
+
 # to speed up re-runs, only re-create environment if needed
-if [[ ! -f local.env ]]; then
+if [[ ! -f local.env ]] || [[ ! -f ${PATH_TO_CLANG_TIDY_SCRIPT} ]]; then
     # automatically setup environment
     ./scripts/setup.sh --config local.env
 fi
 
 # source the environment
 source local.env
-
-PATH_TO_CLANG_TIDY_SCRIPT="$(pwd)/mason_packages/.link/share/run-clang-tidy.py"
-
-# to speed up re-runs, only install clang-tidy if needed
-if [[ ! -f PATH_TO_CLANG_TIDY_SCRIPT ]]; then
-    # The MASON_LLVM_RELEASE variable comes from `local.env`
-    mason-js install clang-tidy=${MASON_LLVM_RELEASE} --type=compiled
-    mason-js link clang-tidy=${MASON_LLVM_RELEASE} --type=compiled
-    # We link the tools to make it easy to know ${PATH_TO_CLANG_TIDY_SCRIPT}
-fi
 
 # build the compile_commands.json file if it does not exist
 if [[ ! -f build/compile_commands.json ]]; then
@@ -51,6 +43,14 @@ if [[ ! -f build/compile_commands.json ]]; then
     # Run make, pipe the output to the generate_compile_commands.py
     # and drop them in a place that clang-tidy will automatically find them
     make | scripts/generate_compile_commands.py > build/compile_commands.json
+fi
+
+# to speed up re-runs, only install clang-tidy if needed
+if [[ ! -f ${PATH_TO_CLANG_TIDY_SCRIPT} ]]; then
+    # The MASON_LLVM_RELEASE variable comes from `local.env`
+    node_modules/.bin/mason-js install clang-tidy=${MASON_LLVM_RELEASE} --type=compiled
+    node_modules/.bin/mason-js link clang-tidy=${MASON_LLVM_RELEASE} --type=compiled
+    # We link the tools to make it easy to know ${PATH_TO_CLANG_TIDY_SCRIPT}
 fi
 
 # change into the build directory so that clang-tidy can find the files

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -13,6 +13,14 @@ function run() {
       echo 'shell_session_update() { :; }' > ~/.direnvrc
     fi
 
+    # Ensure toolchain is installed via mason-js
+    if [[ ! -f ./node_modules/.bin/mason-js ]]; then
+      npm install mason-js-sdk
+    fi
+
+    node_modules/.bin/mason-js install clang++=${MASON_LLVM_RELEASE} --type=compiled
+    node_modules/.bin/mason-js link clang++=${MASON_LLVM_RELEASE} --type=compiled
+
     #
     # ENV SETTINGS
     #

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,17 +3,7 @@
 set -eu
 set -o pipefail
 
-export MASON_RELEASE="${MASON_RELEASE:-35d812c}"
 export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-5.0.0}"
-
-PLATFORM=$(uname | tr A-Z a-z)
-if [[ ${PLATFORM} == 'darwin' ]]; then
-  PLATFORM="osx"
-fi
-
-MASON_URL="https://s3.amazonaws.com/mason-binaries/${PLATFORM}-$(uname -m)"
-
-llvm_toolchain_dir="$(pwd)/.toolchain"
 
 function run() {
     local config=${1}
@@ -24,56 +14,14 @@ function run() {
     fi
 
     #
-    # COMPILER TOOLCHAIN
-    #
-
-    # We install clang++ without the mason client for a couple reasons:
-    # 1) decoupling makes it viable to use a custom branch of mason that might
-    #    modify the upstream s3 bucket in a such a way that does not give
-    #    it access to build tools like clang++
-    # 2) Allows us to short-circuit and use a global clang++ install if it
-    #    is available to save space for local builds.
-    GLOBAL_CLANG="${HOME}/.mason/mason_packages/${PLATFORM}-$(uname -m)/clang++/${MASON_LLVM_RELEASE}"
-    GLOBAL_LLVM="${HOME}/.mason/mason_packages/${PLATFORM}-$(uname -m)/llvm/${MASON_LLVM_RELEASE}"
-    if [[ -d ${GLOBAL_LLVM} ]]; then
-      echo "Detected '${GLOBAL_LLVM}/bin/clang++', using it"
-      local llvm_toolchain_dir=${GLOBAL_LLVM}
-    elif [[ -d ${GLOBAL_CLANG} ]]; then
-      echo "Detected '${GLOBAL_CLANG}/bin/clang++', using it"
-      local llvm_toolchain_dir=${GLOBAL_CLANG}
-    elif [[ -d ${GLOBAL_CLANG} ]]; then
-      echo "Detected '${GLOBAL_CLANG}/bin/clang++', using it"
-      local llvm_toolchain_dir=${GLOBAL_CLANG}
-    elif [[ ! -d ${llvm_toolchain_dir} ]]; then
-      BINARY="${MASON_URL}/clang++/${MASON_LLVM_RELEASE}.tar.gz"
-      echo "Downloading ${BINARY}"
-      mkdir -p ${llvm_toolchain_dir}
-      curl -sSfL ${BINARY} | tar --gunzip --extract --strip-components=1 --directory=${llvm_toolchain_dir}
-    fi
-
-    #
-    # MASON
-    #
-
-    function setup_mason() {
-      local install_dir=${1}
-      local mason_release=${2}
-      mkdir -p ${install_dir}
-      curl -sSfL https://github.com/mapbox/mason/archive/${mason_release}.tar.gz | tar --gunzip --extract --strip-components=1 --directory=${install_dir}
-    }
-
-    setup_mason $(pwd)/.mason ${MASON_RELEASE}
-
-    #
     # ENV SETTINGS
     #
 
-    echo "export PATH=${llvm_toolchain_dir}/bin:$(pwd)/.mason:$(pwd)/mason_packages/.link/bin:"'${PATH}' > ${config}
-    echo "export CXX=${CXX:-${llvm_toolchain_dir}/bin/clang++}" >> ${config}
-    echo "export MASON_RELEASE=${MASON_RELEASE}" >> ${config}
+    echo "export PATH=$(pwd)/.mason:$(pwd)/mason_packages/.link/bin:"'${PATH}' > ${config}
+    echo "export CXX=${CXX:-$(pwd)/mason_packages/.link/bin/clang++}" >> ${config}
     echo "export MASON_LLVM_RELEASE=${MASON_LLVM_RELEASE}" >> ${config}
     # https://github.com/google/sanitizers/wiki/AddressSanitizerAsDso
-    RT_BASE=${llvm_toolchain_dir}/lib/clang/${MASON_LLVM_RELEASE}/lib/$(uname | tr A-Z a-z)/libclang_rt
+    RT_BASE=$(pwd)/mason_packages/.link/lib/clang/${MASON_LLVM_RELEASE}/lib/$(uname | tr A-Z a-z)/libclang_rt
     if [[ $(uname -s) == 'Darwin' ]]; then
         RT_PRELOAD=${RT_BASE}.asan_osx_dynamic.dylib
     else
@@ -85,8 +33,8 @@ function run() {
     echo "leak:v8::internal" >> ${SUPPRESSION_FILE}
     echo "leak:node::CreateEnvironment" >> ${SUPPRESSION_FILE}
     echo "leak:node::Init" >> ${SUPPRESSION_FILE}
-    echo "export ASAN_SYMBOLIZER_PATH=${llvm_toolchain_dir}/bin/llvm-symbolizer" >> ${config}
-    echo "export MSAN_SYMBOLIZER_PATH=${llvm_toolchain_dir}/bin/llvm-symbolizer" >> ${config}
+    echo "export ASAN_SYMBOLIZER_PATH=$(pwd)/mason_packages/.link/bin/llvm-symbolizer" >> ${config}
+    echo "export MSAN_SYMBOLIZER_PATH=$(pwd)/mason_packages/.link/bin/llvm-symbolizer" >> ${config}
     echo "export UBSAN_OPTIONS=print_stacktrace=1" >> ${config}
     echo "export LSAN_OPTIONS=suppressions=${SUPPRESSION_FILE}" >> ${config}
     echo "export ASAN_OPTIONS=symbolize=1:abort_on_error=1:detect_container_overflow=1:check_initialization_order=1:detect_stack_use_after_return=1" >> ${config}


### PR DESCRIPTION
Working on further advances on top of #67. So far this:

 - Takes the opportunity to overhaul the clang++ related scripts.
 - Attempts to fix the clang-tidy and format scripts by ensuring that all the right deps are installed, in the right order, even when `mason-js` has created a `/mason_packages` folder.
 - Adds more docs to the Makefile to explain why it is the way it is
 - Starts using mason-js to clean up more bash script in `./scripts/setup.sh`.
 - Fixes the package.json to also run `mason-js link` to ensure that `npm install --build-from-source` also works