### PR TITLE
implement gzip decompression in vtquery

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -63,6 +63,9 @@
         './src/module.cpp',
         './src/vtquery.cpp'
       ],
+      "link_settings": {
+          "libraries": [ "-lz" ]
+      },
       'ldflags': [
         '-Wl,-z,now',
       ],

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -20,3 +20,4 @@ install spatial-algorithms 0.1.0
 install boost 1.65.1
 install cheap-ruler 2.5.3
 install vector-tile f4728da
+install gzip bb80aac

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,8 +3,8 @@
 set -eu
 set -o pipefail
 
-export MASON_RELEASE="${MASON_RELEASE:-35d812c}"
-export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-5.0.0}"
+export MASON_RELEASE="${MASON_RELEASE:-a47a0e2}"
+export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-6.0.0}"
 
 PLATFORM=$(uname | tr A-Z a-z)
 if [[ ${PLATFORM} == 'darwin' ]]; then
@@ -89,8 +89,8 @@ function run() {
     echo "export MSAN_SYMBOLIZER_PATH=${llvm_toolchain_dir}/bin/llvm-symbolizer" >> ${config}
     echo "export UBSAN_OPTIONS=print_stacktrace=1" >> ${config}
     echo "export LSAN_OPTIONS=suppressions=${SUPPRESSION_FILE}" >> ${config}
-    echo "export ASAN_OPTIONS=symbolize=1:abort_on_error=1:detect_container_overflow=1:check_initialization_order=1:detect_stack_use_after_return=1" >> ${config}
-    echo 'export MASON_SANITIZE="-fsanitize=address,undefined,integer -fno-sanitize=vptr,function"' >> ${config}
+    echo "export ASAN_OPTIONS=detect_leaks=1:symbolize=1:abort_on_error=1:detect_container_overflow=1:check_initialization_order=1:detect_stack_use_after_return=1" >> ${config}
+    echo 'export MASON_SANITIZE="-fsanitize=address,undefined,integer,leak -fno-sanitize=vptr,function"' >> ${config}
     echo 'export MASON_SANITIZE_CXXFLAGS="${MASON_SANITIZE} -fno-sanitize=vptr,function -fsanitize-address-use-after-scope -fno-omit-frame-pointer -fno-common"' >> ${config}
     echo 'export MASON_SANITIZE_LDFLAGS="${MASON_SANITIZE}"' >> ${config}
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,7 +4,7 @@ set -eu
 set -o pipefail
 
 export MASON_RELEASE="${MASON_RELEASE:-a47a0e2}"
-export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-6.0.0}"
+export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-5.0.1}"
 
 PLATFORM=$(uname | tr A-Z a-z)
 if [[ ${PLATFORM} == 'darwin' ]]; then

--- a/src/vtquery.cpp
+++ b/src/vtquery.cpp
@@ -377,7 +377,7 @@ struct Worker : Nan::AsyncWorker {
             }         // end tile loop
             // Here we create "materialized" properties. We do this because, when reading from a compressed
             // buffer, it is unsafe to touch `feature.properties_vector` once we've left this loop.
-            // That is because the compressed buffer above is temporary and re-used for optimal performance.
+            // That is because the buffer may represent uncompressed data that is not in scope outside of Execute()
             for (auto& feature : results_queue_) {
                 feature.properties_vector_materialized.reserve(feature.properties_vector.size());
                 for (auto const& property : feature.properties_vector) {

--- a/src/vtquery.cpp
+++ b/src/vtquery.cpp
@@ -44,6 +44,7 @@ struct ResultObject {
     uint64_t id;
 
     ResultObject() : properties_vector(),
+                     properties_vector_materialized(),
                      layer_name(),
                      coordinates(0.0, 0.0),
                      distance(std::numeric_limits<double>::max()),

--- a/src/vtquery.cpp
+++ b/src/vtquery.cpp
@@ -15,6 +15,8 @@
 #include <utility>
 #include <vtzero/types.hpp>
 #include <vtzero/vector_tile.hpp>
+#include <gzip/decompress.hpp>
+#include <gzip/utils.hpp>
 
 namespace VectorTileQuery {
 
@@ -28,9 +30,12 @@ const char* getGeomTypeString(int enumVal) {
     return GeomTypeStrings[enumVal];
 }
 
+using materialized_prop_type = std::pair<std::string,mapbox::feature::value>;
+
 /// main storage item for returning to the user
 struct ResultObject {
     std::vector<vtzero::property> properties_vector;
+    std::vector<materialized_prop_type> properties_vector_materialized;
     std::string layer_name;
     mapbox::geometry::point<double> coordinates;
     double distance;
@@ -152,11 +157,9 @@ struct property_value_visitor {
 };
 
 /// used to create the final v8 (JSON) object to return to the user
-void set_property(vtzero::property const& property,
+void set_property(materialized_prop_type const& property,
                   v8::Local<v8::Object>& properties_obj) {
-
-    auto val = vtzero::convert_property_value<mapbox::feature::value, mapbox::vector_tile::detail::property_value_mapping>(property.value());
-    mapbox::util::apply_visitor(property_value_visitor{properties_obj, std::string(property.key())}, val);
+    mapbox::util::apply_visitor(property_value_visitor{properties_obj, property.first}, property.second);
 }
 
 GeomType get_geometry_type(vtzero::feature const& f) {
@@ -270,11 +273,25 @@ struct Worker : Nan::AsyncWorker {
             // query point lng/lat geometry.hpp point (used for distance calculation later on)
             mapbox::geometry::point<double> query_lnglat{data.longitude, data.latitude};
 
-            // for each tile
+            gzip::Decompressor decompressor;
+            std::string uncompressed;
+            std::vector<std::string> buffers;
+            std::vector<std::tuple<vtzero::vector_tile,std::uint32_t,std::uint32_t,std::uint32_t>> tiles;
+            tiles.reserve(data.tiles.size());
             for (auto const& tile_ptr : data.tiles) {
                 TileObject const& tile_obj = *tile_ptr;
-                vtzero::vector_tile tile{tile_obj.data};
+                if (gzip::is_compressed(tile_obj.data.data(),tile_obj.data.size())) {
+                    decompressor.decompress(uncompressed,tile_obj.data.data(),tile_obj.data.size());
+                    buffers.emplace_back(std::move(uncompressed));
+                    tiles.emplace_back(vtzero::vector_tile(buffers.back()),tile_obj.z, tile_obj.x, tile_obj.y);
+                } else {
+                    tiles.emplace_back(vtzero::vector_tile(tile_obj.data),tile_obj.z, tile_obj.x, tile_obj.y);
+                }
+            }
 
+            // for each tile
+            for (auto & tile_obj : tiles) {
+                vtzero::vector_tile & tile = std::get<0>(tile_obj);
                 while (auto layer = tile.next_layer()) {
 
                     // check if this is a layer we should query
@@ -284,8 +301,11 @@ struct Worker : Nan::AsyncWorker {
                     }
 
                     std::uint32_t extent = layer.extent();
+                    std::uint32_t tile_obj_z = std::get<1>(tile_obj);
+                    std::uint32_t tile_obj_x = std::get<2>(tile_obj);
+                    std::uint32_t tile_obj_y = std::get<3>(tile_obj);
                     // query point in relation to the current tile the layer extent
-                    mapbox::geometry::point<std::int64_t> query_point = utils::create_query_point(data.longitude, data.latitude, data.zoom, extent, tile_obj.x, tile_obj.y);
+                    mapbox::geometry::point<std::int64_t> query_point = utils::create_query_point(data.longitude, data.latitude, data.zoom, extent, tile_obj_x, tile_obj_y);
 
                     while (auto feature = layer.next_feature()) {
                         auto original_geometry_type = get_geometry_type(feature);
@@ -308,7 +328,7 @@ struct Worker : Nan::AsyncWorker {
 
                         // if distance from the query point is greater than 0.0 (not a direct hit) so recalculate the latlng
                         if (cp_info.distance > 0.0) {
-                            ll = utils::convert_vt_to_ll(extent, tile_obj.z, tile_obj.x, tile_obj.y, cp_info);
+                            ll = utils::convert_vt_to_ll(extent, tile_obj_z, tile_obj_x, tile_obj_y, cp_info);
                             meters = utils::distance_in_meters(query_lnglat, ll);
                         }
 
@@ -354,6 +374,18 @@ struct Worker : Nan::AsyncWorker {
                     } // end tile.layer.feature loop
                 }     // end tile.layer loop
             }         // end tile loop
+            // Here we create "materialized" properties. We do this because, when reading from a compressed
+            // buffer, it is unsafe to touch `feature.properties_vector` once we've left this loop.
+            // That is because the compressed buffer above is temporary and re-used for optimal performance.
+            for (auto & feature : results_queue_) {
+                feature.properties_vector_materialized.reserve(feature.properties_vector.size());
+                for (auto const& property : feature.properties_vector) {
+                    auto val = vtzero::convert_property_value<mapbox::feature::value, mapbox::vector_tile::detail::property_value_mapping>(property.value());
+                    feature.properties_vector_materialized.emplace_back(std::string(property.key()),std::move(val));
+                }
+                // we are now done with the feature.properties_vector
+                //feature.properties_vector.clear();
+            }
         } catch (const std::exception& e) {
             SetErrorMessage(e.what());
         }
@@ -385,7 +417,7 @@ struct Worker : Nan::AsyncWorker {
 
                 // create properties object
                 v8::Local<v8::Object> properties_obj = Nan::New<v8::Object>();
-                for (auto const& prop : feature.properties_vector) {
+                for (auto const& prop : feature.properties_vector_materialized) {
                     set_property(prop, properties_obj);
                 }
 


### PR DESCRIPTION
🍎 This branch, doing decompression in JS (like mapbox-maps)

```
$ node bench/vtquery.bench.js --iterations 500 --concurrency 4 --gzipjs

1: pip: many building polygons ... 1613 runs/s (310ms)
2: pip: many building polygons, single layer ... 1838 runs/s (272ms)
3: query: many building polygons, single layer ... 1466 runs/s (341ms)
4: query: linestrings, mapbox streets roads ... 2632 runs/s (190ms)
5: query: polygons, mapbox streets buildings ... 1484 runs/s (337ms)
6: query: all things - dense single tile ... 871 runs/s (574ms)
7: query: all things - dense nine tiles ... 108 runs/s (4612ms)
8: elevation: terrain tile nepal ... 1326 runs/s (377ms)
9: geometry: 2000 points in a single tile, no properties ... 3311 runs/s (151ms)
10: geometry: 2000 points in a single tile, with properties ... 1543 runs/s (324ms)
11: geometry: 2000 linestrings in a single tile, no properties ... 1969 runs/s (254ms)
12: geometry: 2000 linestrings in a single tile, with properties ... 1362 runs/s (367ms)
13: geometry: 2000 polygons in a single tile, no properties ... 1348 runs/s (371ms)
14: geometry: 2000 polygons in a single tile, with properties ... 1059 runs/s (472ms)
```

🍏 This branch, doing decompression with gzip-hpp
```
~/projects/vtquery[async-gzip]$ node bench/vtquery.bench.js --iterations 500 --concurrency 4
1: pip: many building polygons ... 2137 runs/s (234ms)
2: pip: many building polygons, single layer ... 2304 runs/s (217ms)
3: query: many building polygons, single layer ... 1667 runs/s (300ms)
4: query: linestrings, mapbox streets roads ... 3205 runs/s (156ms)
5: query: polygons, mapbox streets buildings ... 1678 runs/s (298ms)
6: query: all things - dense single tile ... 919 runs/s (544ms)
7: query: all things - dense nine tiles ... 125 runs/s (4012ms)
8: elevation: terrain tile nepal ... 1786 runs/s (280ms)
9: geometry: 2000 points in a single tile, no properties ... 3731 runs/s (134ms)
10: geometry: 2000 points in a single tile, with properties ... 2033 runs/s (246ms)
11: geometry: 2000 linestrings in a single tile, no properties ... 2101 runs/s (238ms)
12: geometry: 2000 linestrings in a single tile, with properties ... 1471 runs/s (340ms)
13: geometry: 2000 polygons in a single tile, no properties ... 1397 runs/s (358ms)
14: geometry: 2000 polygons in a single tile, with properties ... 1075 runs/s (465ms)
```


🍊 Master branch of vtquery (not doing any gzip compression at all). Note: not that much faster than 🍏 
```
$ node bench/vtquery.bench.js --iterations 500 --concurrency 4

1: pip: many building polygons ... 2415 runs/s (207ms)
2: pip: many building polygons, single layer ... 2646 runs/s (189ms)
3: query: many building polygons, single layer ... 1825 runs/s (274ms)
4: query: linestrings, mapbox streets roads ... 3704 runs/s (135ms)
5: query: polygons, mapbox streets buildings ... 1748 runs/s (286ms)
6: query: all things - dense single tile ... 1037 runs/s (482ms)
7: query: all things - dense nine tiles ... 139 runs/s (3601ms)
8: elevation: terrain tile nepal ... 2058 runs/s (243ms)
9: geometry: 2000 points in a single tile, no properties ... 4237 runs/s (118ms)
10: geometry: 2000 points in a single tile, with properties ... 2183 runs/s (229ms)
11: geometry: 2000 linestrings in a single tile, no properties ... 2242 runs/s (223ms)
12: geometry: 2000 linestrings in a single tile, with properties ... 1488 runs/s (336ms)
13: geometry: 2000 polygons in a single tile, no properties ... 1205 runs/s (415ms)
14: geometry: 2000 polygons in a single tile, with properties ... 1109 runs/s (451ms)
```