### PR TITLE
allow multiple zoom levels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtquery",
-  "version": "0.1.0",
+  "version": "0.2.0-zooms",
   "description": "Get features from Mapbox Vector Tiles from a lng/lat query point",
   "url": "http://github.com/mapbox/vtquery",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtquery",
-  "version": "0.2.0-zooms2",
+  "version": "0.2.0-zooms3",
   "description": "Get features from Mapbox Vector Tiles from a lng/lat query point",
   "url": "http://github.com/mapbox/vtquery",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtquery",
-  "version": "0.2.0-zooms",
+  "version": "0.2.0-zooms2",
   "description": "Get features from Mapbox Vector Tiles from a lng/lat query point",
   "url": "http://github.com/mapbox/vtquery",
   "main": "./lib/index.js",

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -51,8 +51,8 @@ struct print_variant {
 */
 mapbox::geometry::point<std::int64_t> create_query_point(double lng,
                                                          double lat,
-                                                         std::int32_t zoom,
                                                          std::uint32_t extent,
+                                                         std::uint32_t active_tile_z,
                                                          std::uint32_t active_tile_x,
                                                          std::uint32_t active_tile_y) {
 
@@ -63,7 +63,7 @@ mapbox::geometry::point<std::int64_t> create_query_point(double lng,
         lat = -89.9;
     }
 
-    double z2 = static_cast<double>(1 << zoom); // number of tiles 'across' a particular zoom level
+    double z2 = static_cast<double>(1 << active_tile_z); // number of tiles 'across' a particular zoom level
     double lat_radian = (lat * M_PI) / 180.0;
     std::int64_t zl_x = static_cast<std::int64_t>(lng / (360.0 / (extent * z2)));
     std::int64_t zl_y = static_cast<std::int64_t>(((extent * z2) / 2.0) * (1.0 - (std::log(std::tan(lat_radian) + 1.0 / std::cos(lat_radian)) / M_PI)));

--- a/test/vtquery.test.js
+++ b/test/vtquery.test.js
@@ -241,28 +241,6 @@ test('failure: buffer object y value is negative', assert => {
   });
 });
 
-test('failure: buffer object z values don\'t match', assert => {
-  const buffs = [
-    {
-      buffer: new Buffer('hey'),
-      z: 0,
-      x: 0,
-      y: 0
-    },
-    {
-      buffer: new Buffer('hi'),
-      z: 1,
-      x: 1,
-      y: 1
-    }
-  ];
-  vtquery(buffs, [47.6117, -122.3444], {}, function(err, result) {
-    assert.ok(err);
-    assert.equal(err.message, '\'z\' values do not match across all tiles in the \'tiles\' array');
-    assert.end();
-  });
-});
-
 test('failure: lnglat is not an array', assert => {
   vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], '[47.6117, -122.3444]', {}, function(err, result) {
     assert.ok(err);
@@ -720,6 +698,27 @@ test('results with same exact distance return in expected order', assert => {
     assert.ok(checkClose(result.features[2].properties.tilequery.distance, 9.436356889343624, 1e-6), 'is the proper distance');
     assert.equal(result.features[3].properties.type, 'pedestrian', 'is expected type');
     assert.ok(checkClose(result.features[3].properties.tilequery.distance, 9.436356889343624, 1e-6), 'is the proper distance');
+    assert.end();
+  });
+});
+
+test.only('success: handles multiple zoom levels', assert => {
+  const buffer1 = fs.readFileSync(path.resolve(__dirname+'/../node_modules/@mapbox/mvt-fixtures/real-world/chicago/13-2098-3045.mvt'));
+  // spoofing a bangkok tile as somewhere over chicago
+  const buffer2 = fs.readFileSync(path.resolve(__dirname+'/../node_modules/@mapbox/mvt-fixtures/real-world/bangkok/12-3188-1888.mvt'));
+
+  const tiles = [
+    { buffer: buffer1, z: 13, x: 2098, y: 3045 },
+    { buffer: buffer2, z: 12, x: 1049, y: 1522 }
+  ];
+  const opts = {
+    radius: 100,
+    layers: ['road_label']
+  };
+  vtquery(tiles, [-87.7718, 41.8464], opts, function(err, result) {
+    assert.equal(result.features[0].properties.iso_3166_2, 'TH-73', 'expected road iso from bangkok');
+    assert.equal(result.features[1].properties.iso_3166_2, 'US-IL', 'expected road iso from chicago');
+    assert.equal(result.features[2].properties.iso_3166_2, 'US-IL', 'expected road iso from chicago');
     assert.end();
   });
 });

--- a/test/vtquery.test.js
+++ b/test/vtquery.test.js
@@ -702,7 +702,7 @@ test('results with same exact distance return in expected order', assert => {
   });
 });
 
-test.only('success: handles multiple zoom levels', assert => {
+test('success: handles multiple zoom levels', assert => {
   const buffer1 = fs.readFileSync(path.resolve(__dirname+'/../node_modules/@mapbox/mvt-fixtures/real-world/chicago/13-2098-3045.mvt'));
   // spoofing a bangkok tile as somewhere over chicago
   const buffer2 = fs.readFileSync(path.resolve(__dirname+'/../node_modules/@mapbox/mvt-fixtures/real-world/bangkok/12-3188-1888.mvt'));


### PR DESCRIPTION
This relaxes the zoom level checks in vtquery to allow buffers to exist across different zooms. Instead of a global zoom level, we use the zoom level from each TileObject structure to perform the distance calculations.

cc @mapbox/core-tech 