### PR TITLE
remove npmignore, use gitignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-lib/binding
-build
-viz
-cloudformation
-node_modules


### PR DESCRIPTION
Removes npmignore, which _radically_ reduces package size by defaulting to the gitignore. 

**before** `54M Apr 12 13:16 mapbox-vtquery-0.1.0.tgz`

**after**: `1.8M Apr 12 13:24 mapbox-vtquery-0.1.0.tgz`

resolves #78 

cc @mapbox/core-tech 