### PR TITLE
update to int32 checks

### DIFF
--- a/src/util.hpp
+++ b/src/util.hpp
@@ -52,9 +52,9 @@ struct print_variant {
 mapbox::geometry::point<std::int64_t> create_query_point(double lng,
                                                          double lat,
                                                          std::uint32_t extent,
-                                                         int active_tile_z,
-                                                         int active_tile_x,
-                                                         int active_tile_y) {
+                                                         std::int32_t active_tile_z,
+                                                         std::int32_t active_tile_x,
+                                                         std::int32_t active_tile_y) {
 
     lng = std::fmod((lng + 180.0), 360.0);
     if (lat > 89.9) {
@@ -82,9 +82,9 @@ mapbox::geometry::point<std::int64_t> create_query_point(double lng,
   Create a geometry.hpp point from vector tile coordinates
 */
 mapbox::geometry::point<double> convert_vt_to_ll(std::uint32_t extent,
-                                                 int z,
-                                                 int x,
-                                                 int y,
+                                                 std::int32_t z,
+                                                 std::int32_t x,
+                                                 std::int32_t y,
                                                  mapbox::geometry::algorithms::closest_point_info cp_info) {
     double z2 = static_cast<double>(static_cast<std::int64_t>(1) << z);
     double ex = static_cast<double>(extent);

--- a/src/vtquery.cpp
+++ b/src/vtquery.cpp
@@ -473,8 +473,8 @@ NAN_METHOD(vtquery) {
             return utils::CallbackError("item in 'tiles' array does not include a 'z' value", callback);
         }
         v8::Local<v8::Value> z_val = tile_obj->Get(Nan::New("z").ToLocalChecked());
-        if (!z_val->IsNumber()) {
-            return utils::CallbackError("'z' value in 'tiles' array item is not a number", callback);
+        if (!z_val->IsInt32()) {
+            return utils::CallbackError("'z' value in 'tiles' array item is not an int32", callback);
         }
         int z = z_val->Int32Value();
         if (z < 0) {
@@ -486,8 +486,8 @@ NAN_METHOD(vtquery) {
             return utils::CallbackError("item in 'tiles' array does not include a 'x' value", callback);
         }
         v8::Local<v8::Value> x_val = tile_obj->Get(Nan::New("x").ToLocalChecked());
-        if (!x_val->IsNumber()) {
-            return utils::CallbackError("'x' value in 'tiles' array item is not a number", callback);
+        if (!x_val->IsInt32()) {
+            return utils::CallbackError("'x' value in 'tiles' array item is not an int32", callback);
         }
         int x = x_val->Int32Value();
         if (x < 0) {
@@ -499,8 +499,8 @@ NAN_METHOD(vtquery) {
             return utils::CallbackError("item in 'tiles' array does not include a 'y' value", callback);
         }
         v8::Local<v8::Value> y_val = tile_obj->Get(Nan::New("y").ToLocalChecked());
-        if (!y_val->IsNumber()) {
-            return utils::CallbackError("'y' value in 'tiles' array item is not a number", callback);
+        if (!y_val->IsInt32()) {
+            return utils::CallbackError("'y' value in 'tiles' array item is not an int32", callback);
         }
         int y = y_val->Int32Value();
         if (y < 0) {

--- a/src/vtquery.cpp
+++ b/src/vtquery.cpp
@@ -55,9 +55,9 @@ struct ResultObject {
 
 /// an intermediate representation of a tile buffer and its necessary components
 struct TileObject {
-    TileObject(int z0,
-               int x0,
-               int y0,
+    TileObject(std::int32_t z0,
+               std::int32_t x0,
+               std::int32_t y0,
                v8::Local<v8::Object> buffer)
         : z(z0),
           x(x0),
@@ -84,9 +84,9 @@ struct TileObject {
     TileObject(TileObject&&) = delete;
     TileObject& operator=(TileObject&&) = delete;
 
-    int z;
-    int x;
-    int y;
+    std::int32_t z;
+    std::int32_t x;
+    std::int32_t y;
     vtzero::data_view data;
     Nan::Persistent<v8::Object> buffer_ref;
 };
@@ -476,7 +476,7 @@ NAN_METHOD(vtquery) {
         if (!z_val->IsInt32()) {
             return utils::CallbackError("'z' value in 'tiles' array item is not an int32", callback);
         }
-        int z = z_val->Int32Value();
+        std::int32_t z = z_val->Int32Value();
         if (z < 0) {
             return utils::CallbackError("'z' value must not be less than zero", callback);
         }
@@ -489,7 +489,7 @@ NAN_METHOD(vtquery) {
         if (!x_val->IsInt32()) {
             return utils::CallbackError("'x' value in 'tiles' array item is not an int32", callback);
         }
-        int x = x_val->Int32Value();
+        std::int32_t x = x_val->Int32Value();
         if (x < 0) {
             return utils::CallbackError("'x' value must not be less than zero", callback);
         }
@@ -502,7 +502,7 @@ NAN_METHOD(vtquery) {
         if (!y_val->IsInt32()) {
             return utils::CallbackError("'y' value in 'tiles' array item is not an int32", callback);
         }
-        int y = y_val->Int32Value();
+        std::int32_t y = y_val->Int32Value();
         if (y < 0) {
             return utils::CallbackError("'y' value must not be less than zero", callback);
         }

--- a/test/vtquery.test.js
+++ b/test/vtquery.test.js
@@ -156,7 +156,7 @@ test('failure: buffer object z value is not a number', assert => {
   ];
   vtquery(buffs, [47.6117, -122.3444], {}, function(err, result) {
     assert.ok(err);
-    assert.equal(err.message, '\'z\' value in \'tiles\' array item is not a number');
+    assert.equal(err.message, '\'z\' value in \'tiles\' array item is not an int32');
     assert.end();
   });
 });
@@ -172,7 +172,7 @@ test('failure: buffer object x value is not a number', assert => {
   ];
   vtquery(buffs, [47.6117, -122.3444], {}, function(err, result) {
     assert.ok(err);
-    assert.equal(err.message, '\'x\' value in \'tiles\' array item is not a number');
+    assert.equal(err.message, '\'x\' value in \'tiles\' array item is not an int32');
     assert.end();
   });
 });
@@ -188,7 +188,7 @@ test('failure: buffer object y value is not a number', assert => {
   ];
   vtquery(buffs, [47.6117, -122.3444], {}, function(err, result) {
     assert.ok(err);
-    assert.equal(err.message, '\'y\' value in \'tiles\' array item is not a number');
+    assert.equal(err.message, '\'y\' value in \'tiles\' array item is not an int32');
     assert.end();
   });
 });


### PR DESCRIPTION
Per discussion in https://github.com/mapbox/vtquery/pull/88#discussion_r193846271 this updates our number checks to be more explicit. 

- [x] Something we can also do is use `std::int32_t` instead of `int` to be even more explicit.

cc @artemp @springmeyer 