### PR TITLE
remove explicit linking to libz

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -63,9 +63,6 @@
         './src/module.cpp',
         './src/vtquery.cpp'
       ],
-      'link_settings': {
-          'libraries': [ '-lz' ]
-      },
       'ldflags': [
         '-Wl,-z,now',
       ],


### PR DESCRIPTION
As part of the PR review of #95, @alliecrevier ask why we explicitly link to libz (which is https://zlib.net/).

I tested without explicit linking and things work fine, so I think we don't need this and it was my mistake to add.

The reason this works (without explicit linking) is that:

 - the module is linked with `-undefined dynamic_lookup` (on OS X) and `rdynamic` (on linux) such that any missing symbols do not prevent the linker from working. The idea is that the module is linked without full symbol resolution and then any missing symbols are expected to be resolved at runtime
 - node.js statically links zlib so the inflate/deflate symbols are able to be found at runtime.


Removing this actually fixes the docker build which I noticed was failing since it was looking for `libz` and could not find it:

```
  clang++ -shared -pthread -rdynamic -m64 -Wl,-z,now  -Wl,-soname=vtquery.node -o /usr/local/src/lib/binding/vtquery.node -Wl,--start-group Release/obj.target/vtquery/src/module.o Release/obj.target/vtquery/src/vtquery.o -Wl,--end-group -lz
/usr/bin/ld: cannot find -lz
clang-5.0: error: linker command failed with exit code 1 (use -v to see invocation)
```
 