### PR TITLE
Generate json in the threadpool

### DIFF
--- a/test/vtquery.test.js
+++ b/test/vtquery.test.js
@@ -24,7 +24,7 @@ test('failure: fails without callback function', assert => {
 });
 
 test('failure: buffers is not an array', assert => {
-  vtquery('i am not an array', [47.6117, -122.3444], {}, function(err, result) {
+  vtquery('i am not an array', [47.6117, -122.3444], {}, function(err) {
     assert.ok(err);
     assert.equal(err.message, 'first arg \'tiles\' must be an array of tile objects');
     assert.end();
@@ -33,7 +33,7 @@ test('failure: buffers is not an array', assert => {
 
 test('failure: buffers array is empty', assert => {
   const buffs = [];
-  vtquery(buffs, [47.6117, -122.3444], {}, function(err, result) {
+  vtquery(buffs, [47.6117, -122.3444], {}, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'tiles\' array must be of length greater than 0');
     assert.end();
@@ -44,7 +44,7 @@ test('failure: item in buffers array is not an object', assert => {
   const buffs = [
     'not an object'
   ];
-  vtquery(buffs, [47.6117, -122.3444], {}, function(err, result) {
+  vtquery(buffs, [47.6117, -122.3444], {}, function(err) {
     assert.ok(err);
     assert.equal(err.message, 'items in \'tiles\' array must be objects');
     assert.end();
@@ -59,7 +59,7 @@ test('failure: buffer value does not exist', assert => {
       y: 0
     }
   ];
-  vtquery(buffs, [47.6117, -122.3444], {}, function(err, result) {
+  vtquery(buffs, [47.6117, -122.3444], {}, function(err) {
     assert.ok(err);
     assert.equal(err.message, 'item in \'tiles\' array does not include a buffer value');
     assert.end();
@@ -75,7 +75,7 @@ test('failure: buffer value is null', assert => {
       y: 0
     }
   ];
-  vtquery(buffs, [47.6117, -122.3444], {}, function(err, result) {
+  vtquery(buffs, [47.6117, -122.3444], {}, function(err) {
     assert.ok(err);
     assert.equal(err.message, 'buffer value in \'tiles\' array item is null or undefined');
     assert.end();
@@ -91,7 +91,7 @@ test('failure: buffer value is not a buffer', assert => {
       y: 0
     }
   ];
-  vtquery(buffs, [47.6117, -122.3444], {}, function(err, result) {
+  vtquery(buffs, [47.6117, -122.3444], {}, function(err) {
     assert.ok(err);
     assert.equal(err.message, 'buffer value in \'tiles\' array item is not a true buffer');
     assert.end();
@@ -107,7 +107,7 @@ test('failure: buffer object missing z value', assert => {
       y: 0
     }
   ];
-  vtquery(buffs, [47.6117, -122.3444], {}, function(err, result) {
+  vtquery(buffs, [47.6117, -122.3444], {}, function(err) {
     assert.ok(err);
     assert.equal(err.message, 'item in \'tiles\' array does not include a \'z\' value');
     assert.end();
@@ -123,7 +123,7 @@ test('failure: buffer object missing x value', assert => {
       y: 0
     }
   ];
-  vtquery(buffs, [47.6117, -122.3444], {}, function(err, result) {
+  vtquery(buffs, [47.6117, -122.3444], {}, function(err) {
     assert.ok(err);
     assert.equal(err.message, 'item in \'tiles\' array does not include a \'x\' value');
     assert.end();
@@ -139,7 +139,7 @@ test('failure: buffer object missing y value', assert => {
       // y: 0
     }
   ];
-  vtquery(buffs, [47.6117, -122.3444], {}, function(err, result) {
+  vtquery(buffs, [47.6117, -122.3444], {}, function(err) {
     assert.ok(err);
     assert.equal(err.message, 'item in \'tiles\' array does not include a \'y\' value');
     assert.end();
@@ -155,7 +155,7 @@ test('failure: buffer object z value is not a number', assert => {
       y: 0
     }
   ];
-  vtquery(buffs, [47.6117, -122.3444], {}, function(err, result) {
+  vtquery(buffs, [47.6117, -122.3444], {}, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'z\' value in \'tiles\' array item is not an int32');
     assert.end();
@@ -171,7 +171,7 @@ test('failure: buffer object x value is not a number', assert => {
       y: 0
     }
   ];
-  vtquery(buffs, [47.6117, -122.3444], {}, function(err, result) {
+  vtquery(buffs, [47.6117, -122.3444], {}, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'x\' value in \'tiles\' array item is not an int32');
     assert.end();
@@ -187,7 +187,7 @@ test('failure: buffer object y value is not a number', assert => {
       y: 'zero'
     }
   ];
-  vtquery(buffs, [47.6117, -122.3444], {}, function(err, result) {
+  vtquery(buffs, [47.6117, -122.3444], {}, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'y\' value in \'tiles\' array item is not an int32');
     assert.end();
@@ -203,7 +203,7 @@ test('failure: buffer object z value is negative', assert => {
       y: 0
     }
   ];
-  vtquery(buffs, [47.6117, -122.3444], {}, function(err, result) {
+  vtquery(buffs, [47.6117, -122.3444], {}, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'z\' value must not be less than zero');
     assert.end();
@@ -219,7 +219,7 @@ test('failure: buffer object x value is negative', assert => {
       y: 0
     }
   ];
-  vtquery(buffs, [47.6117, -122.3444], {}, function(err, result) {
+  vtquery(buffs, [47.6117, -122.3444], {}, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'x\' value must not be less than zero');
     assert.end();
@@ -235,7 +235,7 @@ test('failure: buffer object y value is negative', assert => {
       y: -4
     }
   ];
-  vtquery(buffs, [47.6117, -122.3444], {}, function(err, result) {
+  vtquery(buffs, [47.6117, -122.3444], {}, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'y\' value must not be less than zero');
     assert.end();
@@ -243,7 +243,7 @@ test('failure: buffer object y value is negative', assert => {
 });
 
 test('failure: lnglat is not an array', assert => {
-  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], '[47.6117, -122.3444]', {}, function(err, result) {
+  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], '[47.6117, -122.3444]', {}, function(err) {
     assert.ok(err);
     assert.equal(err.message, 'second arg \'lnglat\' must be an array with [longitude, latitude] values');
     assert.end();
@@ -251,7 +251,7 @@ test('failure: lnglat is not an array', assert => {
 });
 
 test('failure: lnglat array is of length != 2', assert => {
-  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3, 'hi'], {}, function(err, result) {
+  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3, 'hi'], {}, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'lnglat\' must be an array of [longitude, latitude]');
     assert.end();
@@ -259,7 +259,7 @@ test('failure: lnglat array is of length != 2', assert => {
 });
 
 test('failure: longitude is not a number', assert => {
-  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], ['47.6', -122.3], {}, function(err, result) {
+  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], ['47.6', -122.3], {}, function(err) {
     assert.ok(err);
     assert.equal(err.message, 'lnglat values must be numbers');
     assert.end();
@@ -267,7 +267,7 @@ test('failure: longitude is not a number', assert => {
 });
 
 test('failure: latitude is not a number', assert => {
-  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, '-122.3'], {}, function(err, result) {
+  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, '-122.3'], {}, function(err) {
     assert.ok(err);
     assert.equal(err.message, 'lnglat values must be numbers');
     assert.end();
@@ -275,7 +275,7 @@ test('failure: latitude is not a number', assert => {
 });
 
 test('failure: options is not an object', assert => {
-  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], 'hi i am options', function(err, result) {
+  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], 'hi i am options', function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'options\' arg must be an object');
     assert.end();
@@ -286,7 +286,7 @@ test('failure: options.dedupe is not a boolean', assert => {
   const opts = {
     dedupe: 'yes please'
   };
-  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err, result) {
+  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'dedupe\' must be a boolean');
     assert.end();
@@ -297,7 +297,7 @@ test('failure: options.radius is not a number', assert => {
   const opts = {
     radius: '4'
   };
-  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err, result) {
+  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'radius\' must be a number');
     assert.end();
@@ -308,7 +308,7 @@ test('failure: options.radius is negative', assert => {
   const opts = {
     radius: -3
   };
-  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err, result) {
+  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'radius\' must be a positive number');
     assert.end();
@@ -319,7 +319,7 @@ test('failure: options.results is not a number', assert => {
   const opts = {
     limit: 'hi'
   };
-  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err, result) {
+  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'limit\' must be a number');
     assert.end();
@@ -330,7 +330,7 @@ test('failure: options.limit is negative', assert => {
   const opts = {
     limit: -10
   };
-  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err, result) {
+  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'limit\' must be 1 or greater');
     assert.end();
@@ -341,7 +341,7 @@ test('failure: options.limit is 0', assert => {
   const opts = {
     limit: 0
   };
-  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err, result) {
+  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'limit\' must be 1 or greater');
     assert.end();
@@ -352,7 +352,7 @@ test('failure: options.limit is greater than 1000', assert => {
   const opts = {
     limit: 2000
   };
-  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err, result) {
+  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'limit\' must be less than 1000');
     assert.end();
@@ -363,7 +363,7 @@ test('failure: options.layers is not an array', assert => {
   const opts = {
     layers: 'not array'
   };
-  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err, result) {
+  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'layers\' must be an array of strings');
     assert.end();
@@ -374,7 +374,7 @@ test('failure: options.layers includes non string values', assert => {
   const opts = {
     layers: [8, 4]
   };
-  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err, result) {
+  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'layers\' values must be strings');
     assert.end();
@@ -385,7 +385,7 @@ test('failure: options.layers includes empty strings', assert => {
   const opts = {
     layers: ['hello', '']
   };
-  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err, result) {
+  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'layers\' values must be non-empty strings');
     assert.end();
@@ -396,7 +396,7 @@ test('failure: options.geometry is not a string', assert => {
   const opts = {
     geometry: 1234
   };
-  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err, result) {
+  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'geometry\' option must be a string');
     assert.end();
@@ -407,7 +407,7 @@ test('failure: options.geometry does not equal an accepted value', assert => {
   const opts = {
     geometry: 'hexagon'
   };
-  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err, result) {
+  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'geometry\' must be \'point\', \'linestring\', or \'polygon\'');
     assert.end();
@@ -418,7 +418,7 @@ test('failure: options.geometry must not be empty', assert => {
   const opts = {
     geometry: ''
   };
-  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err, result) {
+  vtquery([{buffer: new Buffer('hey'), z: 0, x: 0, y: 0}], [47.6, -122.3], opts, function(err) {
     assert.ok(err);
     assert.equal(err.message, '\'geometry\' value must be a non-empty string');
     assert.end();
@@ -435,7 +435,8 @@ test('options - radius: all results within radius', assert => {
   const expected = JSON.parse(fs.readFileSync(expected_path));
   const buffer = bufferSF;
   const ll = [-122.4477, 37.7665]; // direct hit
-  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, { limit: 100, radius: 1000 }, function(err, result) {
+  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, { limit: 100, radius: 1000 }, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.ifError(err);
     if (process.env.UPDATE) {
       fs.writeFileSync(expected_path,JSON.stringify(result,null,2));
@@ -460,7 +461,8 @@ test('options - radius: all results are in expected order', assert => {
   const expected = JSON.parse(fs.readFileSync(expected_path));
   const buffer = fs.readFileSync(path.resolve(__dirname+'/../node_modules/@mapbox/mvt-fixtures/real-world/chicago/13-2098-3045.mvt'));
   const ll = [-87.7987, 41.8451];
-  vtquery([{buffer: buffer, z: 13, x: 2098, y: 3045}], ll, { radius: 50 }, function(err, result) {
+  vtquery([{buffer: buffer, z: 13, x: 2098, y: 3045}], ll, { radius: 50 }, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.ifError(err);
     if (process.env.UPDATE) {
       fs.writeFileSync(expected_path,JSON.stringify(result,null,2));
@@ -482,7 +484,8 @@ test('options - radius: all results are in expected order', assert => {
 test('options - radius=0: only returns "point in polygon" results (on a building)', assert => {
   const buffer = bufferSF;
   const ll = [-122.4527, 37.7689]; // direct hit on a building
-  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, { radius: 0, layers: ['building'] }, function(err, result) {
+  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, { radius: 0, layers: ['building'] }, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.ifError(err);
     assert.equal(result.features.length, 1, 'only one building returned');
     assert.equal(result.features[0].properties.height, 7, 'expected property value');
@@ -494,7 +497,8 @@ test('options - radius=0: only returns "point in polygon" results (on a building
 test('options - radius=0: returns only radius 0.0 results', assert => {
   const buffer = bufferSF;
   const ll = [-122.4527, 37.7689]; // direct hit on a building
-  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, { radius: 0, limit: 100 }, function(err, result) {
+  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, { radius: 0, limit: 100 }, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.ifError(err);
     result.features.forEach(function(feature) {
       assert.ok(feature.properties.tilequery.distance == 0.0, 'radius 0.0');
@@ -506,7 +510,8 @@ test('options - radius=0: returns only radius 0.0 results', assert => {
 test('options - limit: successfully limits results', assert => {
   const buffer = bufferSF;
   const ll = [-122.4477, 37.7665]; // direct hit
-  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, { limit: 1, radius: 1000 }, function(err, result) {
+  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, { limit: 1, radius: 1000 }, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.ifError(err);
     assert.equal(result.features.length, 1, 'expected length');
     assert.end();
@@ -516,7 +521,8 @@ test('options - limit: successfully limits results', assert => {
 test('options - layers: successfully returns only requested layers', assert => {
   const buffer = bufferSF;
   const ll = [-122.4477, 37.7665]; // direct hit
-  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, {radius: 2000, layers: ['poi_label']}, function(err, result) {
+  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, {radius: 2000, layers: ['poi_label']}, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.ifError(err);
     result.features.forEach(function(feature) {
       assert.equal(feature.properties.tilequery.layer, 'poi_label', 'proper layer');
@@ -528,7 +534,8 @@ test('options - layers: successfully returns only requested layers', assert => {
 test('options - layers: returns zero results for a layer that does not exist - does not error', assert => {
   const buffer = bufferSF;
   const ll = [-122.4477, 37.7665]; // direct hit
-  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, {radius: 2000, layers: ['i_am_not_real']}, function(err, result) {
+  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, {radius: 2000, layers: ['i_am_not_real']}, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.ifError(err);
     assert.equal(result.features.length, 0, 'no features');
     assert.end();
@@ -538,7 +545,8 @@ test('options - layers: returns zero results for a layer that does not exist - d
 test('options - radius: all results within radius', assert => {
   const buffer = bufferSF;
   const ll = [-122.4477, 37.7665]; // direct hit
-  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, { limit: 100, radius: 1000 }, function(err, result) {
+  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, { limit: 100, radius: 1000 }, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.ifError(err);
     result.features.forEach(function(feature) {
       assert.ok(feature.properties.tilequery.distance <= 1000, 'less than radius');
@@ -550,7 +558,8 @@ test('options - radius: all results within radius', assert => {
 test('options - geometry: successfully returns only points', assert => {
   const buffer = bufferSF;
   const ll = [-122.4477, 37.7665]; // direct hit
-  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, {radius: 2000, geometry: 'point'}, function(err, result) {
+  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, {radius: 2000, geometry: 'point'}, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.ifError(err);
     assert.equal(result.features.length, 5, 'expected number of features');
     result.features.forEach(function(feature) {
@@ -563,7 +572,8 @@ test('options - geometry: successfully returns only points', assert => {
 test('options - geometry: successfully returns only linestrings', assert => {
   const buffer = bufferSF;
   const ll = [-122.4477, 37.7665]; // direct hit
-  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, {radius: 200, geometry: 'linestring'}, function(err, result) {
+  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, {radius: 200, geometry: 'linestring'}, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.ifError(err);
     assert.equal(result.features.length, 5, 'expected number of features');
     result.features.forEach(function(feature) {
@@ -577,7 +587,8 @@ test('options - geometry: successfully returns only linestrings', assert => {
 test('options - geometry: successfully returns only polygons', assert => {
   const buffer = bufferSF;
   const ll = [-122.4477, 37.7665]; // direct hit
-  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, {radius: 200, geometry: 'polygon'}, function(err, result) {
+  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, {radius: 200, geometry: 'polygon'}, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.ifError(err);
     assert.equal(result.features.length, 5, 'expected number of features');
     result.features.forEach(function(feature) {
@@ -600,7 +611,8 @@ test('options - dedupe: returns only one result when dedupe is on', assert => {
   const opts = {
     radius: 10000 // about the width of a z15 tile
   }
-  vtquery(tiles, [-100.9797421880223, 50.075683473759085], opts, function(err, result) {
+  vtquery(tiles, [-100.9797421880223, 50.075683473759085], opts, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.ifError(err);
     assert.equal(result.features.length, 1, 'only one feature');
     assert.equal(result.features[0].properties.tilequery.distance, 0, 'expected distance');
@@ -620,7 +632,8 @@ test('options - dedupe: removes results from deque when a closer result is found
   const opts = {
     radius: 10000 // about the width of a z15 tile
   }
-  vtquery(tiles, [-100.9797421880223, 50.075683473759085], opts, function(err, result) {
+  vtquery(tiles, [-100.9797421880223, 50.075683473759085], opts, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.ifError(err);
     assert.equal(result.features.length, 1, 'only one feature');
     assert.equal(result.features[0].properties.tilequery.distance, 0, 'expected distance');
@@ -639,7 +652,8 @@ test('options - dedupe: returns duplicate results when dedupe is off', assert =>
     radius: 10000, // about the width of a z15 tile
     dedupe: false
   }
-  vtquery(tiles, [-100.9797421880223, 50.075683473759085], opts, function(err, result) {
+  vtquery(tiles, [-100.9797421880223, 50.075683473759085], opts, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.ifError(err);
     assert.equal(result.features.length, 2, 'two features');
     assert.equal(result.features[0].properties.tilequery.distance, 0, 'expected distance');
@@ -658,7 +672,8 @@ test('options - dedupe: compare fields for features that have no id (increases c
   const opts = {
     radius: 10000 // should encompass each point in each tile
   };
-  vtquery(tiles, [-122.453, 37.767], opts, function(err, result) {
+  vtquery(tiles, [-122.453, 37.767], opts, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.ifError(err);
     assert.equal(result.features.length, 1, 'expected number of features');
     assert.end();
@@ -674,7 +689,8 @@ test('options - dedupe: compare fields from real-world tiles (increases coverage
     limit: 20,
     radius: 300 // should encompass each point in each tile
   };
-  vtquery(tiles, [-122.453, 37.767], opts, function(err, result) {
+  vtquery(tiles, [-122.453, 37.767], opts, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.ifError(err);
     assert.equal(result.features.length, 20, 'expected number of features');
     assert.end();
@@ -686,7 +702,8 @@ test('success: returns all possible data value types', assert => {
   const opts = {
     radius: 800 // about the width of a z15 tile
   }
-  vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result) {
+  vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result_string) {
+    const result = JSON.parse(result_string);
     const p = result.features[0].properties;
 
     assert.equal(typeof p.string_value, 'string', 'expected value type');
@@ -709,7 +726,8 @@ test('success: does not throw on unknown geometry type', assert => {
   const opts = {
     radius: 800 // about the width of a z15 tile
   }
-  vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result) {
+  vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.ifError(err);
     assert.notOk(result.features.length);
     assert.end();
@@ -721,7 +739,7 @@ test('error: throws on invalid tile that is missing geometry type', assert => {
   const opts = {
     radius: 800 // about the width of a z15 tile
   }
-  vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result) {
+  vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result_string) {
     assert.ok(err);
     assert.equal(err.message, 'Missing geometry field in feature (spec 4.2)', 'expected error message');
     assert.end();
@@ -732,7 +750,8 @@ test('results with same exact distance return in expected order', assert => {
   // this query returns four results, three of which are the exact same distance and different types of features
   const buffer = fs.readFileSync(path.resolve(__dirname+'/../node_modules/@mapbox/mvt-fixtures/real-world/chicago/13-2098-3045.mvt'));
   const ll = [-87.7964, 41.8675];
-  vtquery([{buffer: buffer, z: 13, x: 2098, y: 3045}], ll, { radius: 10, layers: ['road'] }, function(err, result) {
+  vtquery([{buffer: buffer, z: 13, x: 2098, y: 3045}], ll, { radius: 10, layers: ['road'] }, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.equal(result.features[1].properties.type, 'turning_circle', 'is expected type');
     assert.ok(checkClose(result.features[1].properties.tilequery.distance, 9.436356889343624, 1e-6), 'is the proper distance');
     assert.equal(result.features[2].properties.type, 'service:driveway', 'is expected type');
@@ -756,7 +775,8 @@ test('success: handles multiple zoom levels', assert => {
     radius: 100,
     layers: ['road_label']
   };
-  vtquery(tiles, [-87.7718, 41.8464], opts, function(err, result) {
+  vtquery(tiles, [-87.7718, 41.8464], opts, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.equal(result.features[0].properties.iso_3166_2, 'TH-73', 'expected road iso from bangkok');
     assert.equal(result.features[1].properties.iso_3166_2, 'US-IL', 'expected road iso from chicago');
     assert.equal(result.features[2].properties.iso_3166_2, 'US-IL', 'expected road iso from chicago');
@@ -777,7 +797,8 @@ test('success: handles multiple zoom levels (with compressed tiles)', assert => 
     radius: 100,
     layers: ['road_label']
   };
-  vtquery(tiles, [-87.7718, 41.8464], opts, function(err, result) {
+  vtquery(tiles, [-87.7718, 41.8464], opts, function(err, result_string) {
+    const result = JSON.parse(result_string);
     assert.equal(result.features[0].properties.iso_3166_2, 'TH-73', 'expected road iso from bangkok');
     assert.equal(result.features[1].properties.iso_3166_2, 'US-IL', 'expected road iso from chicago');
     assert.equal(result.features[2].properties.iso_3166_2, 'US-IL', 'expected road iso from chicago');


### PR DESCRIPTION
This is an experimental PR that moves the JSON response creation to happen, asynchronously, in the C++ threadpool. The motivation here is:

 - This will result in less main event loop blocking, since the v8 object creation it replaces was happening synchronously
 - This will result in less allocations and therefore less garbage collection churn and pauses, since we're now creating a single JS object to hold the response string rather than many small objects to form up the JSON tree
 - Now that we pass across a single string as a response, in the future if we wanted to compress the response it would be easy to do in the threadpool using gzip-hpp before sending across the threadpool.

Caveats:
  - This works, but likely needs more testing
  - This is probably not as fast as it could be since:
    - `std::to_string` is used heavily and is know to be not as fast as specialized conversion methods
    - string concatenation is used and requires small C++ allocations. We could likely save on allocations by using a `StrCat` approach like https://abseil.io/tips/3

/cc @mapbox/maps-api @mapsam 