### PR TITLE
Basic Numeric and Boolean Filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,22 +39,6 @@ script:
 # run your tests and build binaries
 matrix:
   include:
-    # linux publishable node v4/release
-    - os: linux
-      env: BUILDTYPE=release
-      node_js: 4
-    # linux publishable node v4/debug
-    - os: linux
-      env: BUILDTYPE=debug
-      node_js: 4
-    # linux publishable node v6
-    - os: linux
-      env: BUILDTYPE=release
-      node_js: 6
-    # linux publishable node v6/debug
-    - os: linux
-      env: BUILDTYPE=debug
-      node_js: 6
     # linux publishable node v8
     - os: linux
       env: BUILDTYPE=release
@@ -71,27 +55,17 @@ matrix:
     - os: linux
       env: BUILDTYPE=debug
       node_js: 10
-    # osx publishable node v4
-    - os: osx
-      osx_image: xcode8.2
-      env: BUILDTYPE=release
-      node_js: 4
-    # osx publishable node v6
-    - os: osx
-      osx_image: xcode8.2
-      env: BUILDTYPE=release
-      node_js: 6
     # osx publishable node v8
     - os: osx
-      osx_image: xcode8.2
+      osx_image: xcode8.3
       env: BUILDTYPE=release
       node_js: 8
     # osx publishable node v10
     - os: osx
-      osx_image: xcode8.2
+      osx_image: xcode8.3
       env: BUILDTYPE=release
       node_js: 10
-    # Sanitizer build node v4/Debug
+    # Sanitizer build node v10/Debug
     - os: linux
       env: BUILDTYPE=debug TOOLSET=asan
       sudo: required # workaround https://github.com/mapbox/node-cpp-skel/issues/93

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,12 +111,14 @@ matrix:
       node_js: 10
       # Overrides `script` to publish coverage data to codecov
       before_script:
-        - npm test
+        - pip install --user codecov
         - mason install llvm-cov ${MASON_LLVM_RELEASE}
         - mason link llvm-cov ${MASON_LLVM_RELEASE}
         - which llvm-cov
         - curl -S -f https://codecov.io/bash -o codecov
         - chmod +x codecov
+      script:
+        - make coverage
         - ./codecov -x "llvm-cov gcov" -Z
     # Clang format build
     - os: linux

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "@mapbox/vtquery",
-  "version": "0.3.0",
+  "version": "0.3.1-basic-filter",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@mapbox/mvt-fixtures": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mvt-fixtures/-/mvt-fixtures-3.4.0.tgz",
-      "integrity": "sha512-NBZ4vQuY2p67cKa21CjtZuhMlHX2gu8RG4EoCglFapQtQJXauV2lxsEFq5hzIgFI8gEo/lIS0ewMQHNwnLhwfw==",
+      "version": "3.6.0-dev1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mvt-fixtures/-/mvt-fixtures-3.6.0-dev1.tgz",
+      "integrity": "sha512-zr2ysE0ge1zbKo2niIrs6m331BEdCRhptXAj17MBnk29UFW7ppkyGRKoVk+3IgkPrtWbjUNOvuQFNnJBhVckqQ==",
       "dev": true,
       "requires": {
         "@mapbox/sphericalmercator": "^1.0.5",
         "@mapbox/vector-tile": "^1.3.0",
         "d3-queue": "^3.0.7",
         "pbf": "^3.0.5",
-        "protocol-buffers-schema": "^3.3.1"
+        "protocol-buffers-schema": "^3.3.2"
       }
     },
     "@mapbox/point-geometry": {
@@ -394,9 +394,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "minimatch": {
@@ -576,13 +576,21 @@
       "dev": true
     },
     "pbf": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.1.0.tgz",
-      "integrity": "sha512-/hYJmIsTmh7fMkHAWWXJ5b8IKLWdjdlAFb3IHkRBn1XUhIYBChVGfVwmHEAV3UfXTxsP/AKfYTXTS/dCPxJd5w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.0.tgz",
+      "integrity": "sha512-98Eh7rsJNJF/Im6XYMLaOW3cLnNyedlOd6hu3iWMD5I7FZGgpw8yN3vQBrmLbLodu7G784Irb9Qsv2yFrxSAGw==",
       "dev": true,
       "requires": {
-        "ieee754": "^1.1.6",
-        "resolve-protobuf-schema": "^2.0.0"
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "dependencies": {
+        "ieee754": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+          "dev": true
+        }
       }
     },
     "process-nextick-args": {
@@ -643,20 +651,12 @@
       }
     },
     "resolve-protobuf-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.0.0.tgz",
-      "integrity": "sha1-5nsGKmfwLRG9aIbnDv2niEB+D7Q=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
       "dev": true,
       "requires": {
-        "protocol-buffers-schema": "^2.0.2"
-      },
-      "dependencies": {
-        "protocol-buffers-schema": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-2.2.0.tgz",
-          "integrity": "sha1-0pxs1z+2VZePtpiWkRgNuEQRn2E=",
-          "dev": true
-        }
+        "protocol-buffers-schema": "^3.3.1"
       }
     },
     "resumer": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtquery",
-  "version": "0.3.0",
+  "version": "0.3.1-basic-filter",
   "description": "Get features from Mapbox Vector Tiles from a lng/lat query point",
   "url": "http://github.com/mapbox/vtquery",
   "main": "./lib/index.js",
@@ -20,7 +20,7 @@
     "node-pre-gyp": "~0.10.2"
   },
   "devDependencies": {
-    "@mapbox/mvt-fixtures": "^3.2.0",
+    "@mapbox/mvt-fixtures": "3.6.0",
     "aws-sdk": "^2.163.0",
     "d3-queue": "^3.0.7",
     "minimist": "^1.2.0",

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -26,4 +26,5 @@ llvm-profdata merge -output=code.profdata code-*.profraw
 llvm-cov report ${CXX_MODULE} -instr-profile=code.profdata -use-color
 llvm-cov show ${CXX_MODULE} -instr-profile=code.profdata src/*.cpp -filename-equivalence -use-color
 llvm-cov show ${CXX_MODULE} -instr-profile=code.profdata src/*.cpp -filename-equivalence -use-color --format html > /tmp/coverage.html
+llvm-cov show ${CXX_MODULE} -instr-profile=code.profdata src/*.cpp -filename-equivalence > coverage.txt
 echo "open /tmp/coverage.html for HTML version of this report"

--- a/test/vtquery.test.js
+++ b/test/vtquery.test.js
@@ -681,11 +681,208 @@ test('options - dedupe: compare fields from real-world tiles (increases coverage
   });
 });
 
+test('options - filter: Empty List', assert => {
+  const tiles = [{buffer: mvtf.get('038').buffer, z: 15, x: 5248, y: 11436}];
+  const opts = {
+    radius: 800, // about the width of a z15 tile
+    'basic-filters': ['all', []]
+  };
+  vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result) {
+    assert.equal(result.features.length, 1, 'expected one feature');
+    assert.ifError(err);
+    assert.end();
+  });
+});
+
+test('options - filter: Invalid Filter Condition', assert => {
+  const tiles = [{buffer: mvtf.get('038').buffer, z: 15, x: 5248, y: 11436}];
+  const opts = {
+    radius: 800, // about the width of a z15 tile
+    'basic-filters': ['all', [['int_value', '==', 6]]]
+  };
+  vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result) {
+    assert.ok(err);
+    assert.equal(err.message, 'condition filter value must be =, !=, <, <=, >, or >=');
+    assert.end();
+  });
+});
+
+test('options - filter: Invalid Filter String', assert => {
+  const tiles = [{buffer: mvtf.get('038').buffer, z: 15, x: 5248, y: 11436}];
+  const opts = {
+    radius: 800, // about the width of a z15 tile
+    'basic-filters': ['all', [['string_value', '=',"Strings_Not_Allowed"]]]
+  };
+  vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result) {
+    assert.ok(err);
+    assert.equal(err.message, 'value filter value must be a number or boolean');
+    assert.end();
+  });
+});
+
+test('options - filter: Invalid Filter Array', assert => {
+  const tiles = [{buffer: mvtf.get('038').buffer, z: 15, x: 5248, y: 11436}];
+  const opts = {
+    radius: 800, // about the width of a z15 tile
+    'basic-filters': ['all', ['int_value', '=', 6]]
+  };
+  vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result) {
+    assert.ok(err);
+    assert.equal(err.message, 'filters must be of the form [parameter, condition, value]');
+    assert.end();
+  });
+});
+
+test('options - filter: Test Int Equals', assert => {
+  const tiles = [{buffer: mvtf.get('038').buffer, z: 15, x: 5248, y: 11436}];
+  const opts = {
+    radius: 800, // about the width of a z15 tile
+    'basic-filters': ['all', [['int_value', '=', 6]]]
+  };
+  vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result) {
+    assert.ifError(err);
+    assert.equal(result.features.length, 1, 'expected one feature');
+    const p = result.features[0].properties;
+    assert.equal(p.int_value, 6, 'expected int value');
+    assert.end();
+  });
+});
+
+test('options - filter: Test Boolean Not Equals', assert => {
+  const tiles = [{buffer: mvtf.get('038').buffer, z: 15, x: 5248, y: 11436}];
+  const opts = {
+    radius: 800, // about the width of a z15 tile
+    'basic-filters': ['all', [['bool_value', '!=', false]]]
+  };
+  vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result) {
+    assert.equal(result.features.length, 1, 'expected one feature');
+    const p = result.features[0].properties;
+    assert.equal(p.bool_value, true, 'expected value type');
+    assert.ifError(err);
+    assert.end();
+  });
+});
+
+test('options - filter: Test Float Approximate Equals', assert => {
+  const tiles = [{buffer: mvtf.get('038').buffer, z: 15, x: 5248, y: 11436}];
+  const opts = {
+    radius: 800, // about the width of a z15 tile
+    'basic-filters': ['all', [['float_value', '=', 3.1]]]
+  };
+  vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result) {
+    assert.equal(result.features.length, 1, 'expected one feature');
+    const p = result.features[0].properties;
+    assert.equal(p.float_value, 3.0999999046325684, 'expected value type');
+    assert.ifError(err);
+    assert.end();
+  });
+});
+
+test('options - filter: Test No Results Less Than Equals', assert => {
+  const tiles = [{buffer: mvtf.get('038').buffer, z: 15, x: 5248, y: 11436}];
+  const opts = {
+    radius: 800, // about the width of a z15 tile
+    'basic-filters': ['all', [['uint_value', '<', 0]]]
+  };
+  vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result) {
+    assert.equal(result.features.length, 0, 'expected one feature');
+    assert.ifError(err);
+    assert.end();
+  });
+});
+
+test('options - filter: Test No Results Greater Than Equals', assert => {
+  const tiles = [{buffer: mvtf.get('038').buffer, z: 15, x: 5248, y: 11436}];
+  const opts = {
+    radius: 800, // about the width of a z15 tile
+    'basic-filters': ['all', [['sint_value', '>', 0]]]
+  };
+  vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result) {
+    assert.equal(result.features.length, 0, 'expected one feature');
+    assert.ifError(err);
+    assert.end();
+  });
+});
+
+test('options - filter: Test Double Int Greater Than Equal', assert => {
+  const tiles = [{buffer: mvtf.get('038').buffer, z: 15, x: 5248, y: 11436}];
+  const opts = {
+    radius: 800, // about the width of a z15 tile
+    'basic-filters': ['all', [['double_value', '>',-2]]]
+  };
+  vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result) {
+    assert.equal(result.features.length, 1, 'expected one feature');
+    const p = result.features[0].properties;
+    assert.equal(p.double_value, 1.23, 'expected value type');
+    assert.ifError(err);
+    assert.end();
+  });
+});
+
+test('options - filter: Test filter with multiple features', assert => {
+  const tiles = [{buffer: mvtf.get('062').buffer, z: 15, x: 5248, y: 11436}];
+  const opts = {
+    radius: 800, // about the width of a z15 tile
+    'basic-filters': ['all', [['population', '>', 10]]]
+  };
+  vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result) {
+    assert.equal(result.features.length, 3, 'expected one feature');
+    let cities = [];
+    for (let i = 0; i < 3; i++) {
+      cities.push(result.features[i].properties.name);
+    }
+    assert.assert(cities.includes('RadEstablishment'), 'Missing RadEstablishment for population check');
+    assert.assert(cities.includes('AwesomeCity'),  'Missing AwesomeCity for population check');
+    assert.assert(cities.includes('TubularTown'), 'Missing TubularTown for population check');
+    assert.ifError(err);
+    assert.end();
+  });
+});
+
+test('options - filter: Test all filter with multiple features', assert => {
+  const tiles = [{buffer: mvtf.get('062').buffer, z: 15, x: 5248, y: 11436}];
+  const opts = {
+    radius: 800, // about the width of a z15 tile
+    'basic-filters': ['all', [['population', '>', 10], ['population', '<', 1000]]]
+  };
+  vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result) {
+    assert.equal(result.features.length, 2, 'expected two features');
+    let cities = [];
+    for (let i = 0; i < 2; i++) {
+      cities.push(result.features[i].properties.name);
+    }
+    assert.assert(cities.includes('RadEstablishment'), 'Missing RadEstablishment for population check');
+    assert.assert(cities.includes('AwesomeCity'),  'Missing AwesomeCity for population check');
+    assert.ifError(err);
+    assert.end();
+  });
+});
+
+test('options - filter: Test any filter with multiple features', assert => {
+  const tiles = [{buffer: mvtf.get('062').buffer, z: 15, x: 5248, y: 11436}];
+  const opts = {
+    radius: 800, // about the width of a z15 tile
+    'basic-filters': ['any', [['population', '<=', 10], ['population', '>', 1000]]]
+  };
+  vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result) {
+    assert.equal(result.features.length, 3, 'expected three features');
+    let cities = [];
+    for (let i = 0; i < 3; i++) {
+      cities.push(result.features[i].properties.name);
+    }
+    assert.assert(cities.includes('Neatville'), 'Missing Neatville for population check');
+    assert.assert(cities.includes('CoolVillage'),  'Missing CoolVillage for population check');
+    assert.assert(cities.includes('TubularTown'),  'Missing TubularTown for population check');
+    assert.ifError(err);
+    assert.end();
+  });
+});
+
 test('success: returns all possible data value types', assert => {
   const tiles = [{buffer: mvtf.get('038').buffer, z: 15, x: 5248, y: 11436}];
   const opts = {
     radius: 800 // about the width of a z15 tile
-  }
+  };
   vtquery(tiles, [-122.3384, 47.6635], opts, function(err, result) {
     const p = result.features[0].properties;
 


### PR DESCRIPTION
## A Basic Filter for VTQuery.
* Enables a feature to be filter if they fail to match the submitted filters
    * A filter saying 'metric' >= 10 will only accept features with a 'metric' greater than or equal to 10.
* Can use a collection of filters
* Can filter numeric or boolean types
    * All numeric types get cast to double to be able to compare between the numeric types

### Related Issues
 * https://github.com/mapbox/vtquery/issues/109

### Current Issues
* Ugly variadic handling
* No string handling due to complexity of UTF-8, string massaging, and undefined expectations for such a feature.