### PR TITLE
Direct Hit Polygon Flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0
+
+* Add `direct_hit_polygon` option to allow queries only allow polygons that contain the query point but still allow points and line segments that are within `radius` distance.
+
 ## 0.4.1
 
 * Improved `basic-filters` performance

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The two major use cases for this library are:
     -   `options.basic-filters` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)>?** an expression-like filter to include features with Numeric or Boolean properties
         that match the filters based on the following conditions: `=, !=, <, <=, >, >=`. The first item must be the value "any" or "all" whether
         any or all filters must evaluate to true.
-    -   `options.direct_hit_polygon` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** defaults to false.  Weh true, a polygon is treated with an allowed radius of 0.0 regardless of how `options.radius` was set.
+    -   `options.direct_hit_polygon` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** defaults to false.  When true, a polygon is treated with an allowed radius of 0.0 regardless of how `options.radius` was set.
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The two major use cases for this library are:
     -   `options.basic-filters` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)>?** an expression-like filter to include features with Numeric or Boolean properties
         that match the filters based on the following conditions: `=, !=, <, <=, >, >=`. The first item must be the value "any" or "all" whether
         any or all filters must evaluate to true.
-    -   `options.direct_hit_polygon` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** defaults to false.  When true, a polygon is treated with an allowed radius of 0.0 regardless of how `options.radius` was set.
+    -   `options.direct_hit_polygon` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** When true, the query will exlcude any polygons that do not contain the query point regardless of the radius value. (Optional, defaults to false)
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The two major use cases for this library are:
     -   `options.basic-filters` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)>?** an expression-like filter to include features with Numeric or Boolean properties
         that match the filters based on the following conditions: `=, !=, <, <=, >, >=`. The first item must be the value "any" or "all" whether
         any or all filters must evaluate to true.
+    -   `options.direct_hit_polygon` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** defaults to false.  Weh true, a polygon is treated with an allowed radius of 0.0 regardless of how `options.radius` was set.
 
 ### Examples
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtquery",
-  "version": "0.4.2-dhp",
+  "version": "0.4.2-dhp-01",
   "description": "Get features from Mapbox Vector Tiles from a lng/lat query point",
   "url": "http://github.com/mapbox/vtquery",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtquery",
-  "version": "0.4.1",
+  "version": "0.4.2-dhp",
   "description": "Get features from Mapbox Vector Tiles from a lng/lat query point",
   "url": "http://github.com/mapbox/vtquery",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtquery",
-  "version": "0.4.2-dhp-01",
+  "version": "0.5.0",
   "description": "Get features from Mapbox Vector Tiles from a lng/lat query point",
   "url": "http://github.com/mapbox/vtquery",
   "main": "./lib/index.js",

--- a/src/vtquery.cpp
+++ b/src/vtquery.cpp
@@ -462,7 +462,7 @@ struct Worker : Nan::AsyncWorker {
                             continue;
                         }
 
-                        // Only allow direct hits for polygons
+                        // If direct_hit_polygon is enabled, disallow polygons that do not contain the point
                         if (meters > 0.0 && original_geometry_type == GeomType::polygon && data.direct_hit_polygon) {
                             continue;
                         }

--- a/src/vtquery.cpp
+++ b/src/vtquery.cpp
@@ -132,6 +132,7 @@ struct QueryData {
           radius(0.0),
           num_results(5),
           dedupe(true),
+          direct_hit_polygon(false),
           geometry_filter_type(GeomType::all) {
         tiles.reserve(num_tiles);
     }
@@ -154,6 +155,7 @@ struct QueryData {
     double radius;
     std::uint32_t num_results;
     bool dedupe;
+    bool direct_hit_polygon;
     GeomType geometry_filter_type;
     meta_filter_struct basic_filter;
 };
@@ -460,6 +462,11 @@ struct Worker : Nan::AsyncWorker {
                             continue;
                         }
 
+                        // Only allow direct hits for polygons
+                        if (meters > 0.0 && original_geometry_type == GeomType::polygon && data.direct_hit_polygon) {
+                            continue;
+                        }
+
                         // If we have filters and the feature doesn't pass the filters, skip this feature
                         if (filter_enabled && !filter_feature(feature, filters, data.basic_filter.type)) {
                             continue;
@@ -709,6 +716,16 @@ NAN_METHOD(vtquery) {
 
             bool dedupe = Nan::To<bool>(dedupe_val).FromJust();
             query_data->dedupe = dedupe;
+        }
+
+        if (Nan::Has(options, Nan::New("direct_hit_polygon").ToLocalChecked()).FromMaybe(false)) {
+            v8::Local<v8::Value> direct_hit_polygon_val = Nan::Get(options, Nan::New("direct_hit_polygon").ToLocalChecked()).ToLocalChecked();
+            if (!direct_hit_polygon_val->IsBoolean()) {
+                return utils::CallbackError("'direct_hit_polygon' must be a boolean", callback);
+            }
+
+            bool direct_hit_polygon = Nan::To<bool>(direct_hit_polygon_val).FromJust();
+            query_data->direct_hit_polygon = direct_hit_polygon;
         }
 
         if (Nan::Has(options, Nan::New("radius").ToLocalChecked()).FromMaybe(false)) {

--- a/test/vtquery.test.js
+++ b/test/vtquery.test.js
@@ -503,6 +503,28 @@ test('options - radius=0: returns only radius 0.0 results', assert => {
   });
 });
 
+test('options - radius=1000, direct_hit_polygon: returns points/lines within 1000.0 and polygons that are direct hits', assert => {
+  const buffer = bufferSF;
+  const ll = [-122.4527, 37.7689]; // direct hit on a building
+  let polygon_count = 0;
+  let non_polygon_count = 0;
+  vtquery([{buffer: buffer, z: 15, x: 5238, y: 12666}], ll, { radius: 1000, limit: 100 , direct_hit_polygon: true}, function(err, result) {
+    assert.ifError(err);
+    result.features.forEach(function(feature) {
+      if (feature.properties.tilequery.geometry === 'polygon') {
+        assert.ok(feature.properties.tilequery.distance == 0.0, 'radius 0.0');
+        polygon_count += 1
+      } else {
+        assert.ok(feature.properties.tilequery.distance <= 1000.0, 'radius 1000.0');
+        non_polygon_count += 1;
+      }
+    });
+    assert.ok(polygon_count > 0, 'at least one polygon');
+    assert.ok(non_polygon_count > 0, 'at least one non-polygon');
+    assert.end();
+  });
+});
+
 test('options - limit: successfully limits results', assert => {
   const buffer = bufferSF;
   const ll = [-122.4477, 37.7665]; // direct hit


### PR DESCRIPTION
Create a flag for overriding radius requirement for polygon features.  When the flag is set to true, radius will only apply to points and lines, thus requiring the point to be internal to polygons (a direct hit).