### PR TITLE
Fix travis - exit code 86

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,7 @@ matrix:
         - make ${BUILDTYPE}
       # Overrides `script` to disable publishing
       script:
+        - true
     # Coverage build
     - os: linux
       env: BUILDTYPE=debug CXXFLAGS="--coverage" LDFLAGS="--coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ matrix:
         - make sanitize
       # Overrides `before_script` (tests are already run in `make sanitize`)
       before_script:
+        - true
 
     ## ** Builds that do not get published **
 
@@ -123,8 +124,10 @@ matrix:
         - make format
       # Overrides `before_script`, no need to run tests
       before_script:
+        - true
       # Overrides `script` to disable publishing
       script:
+        - true
     # Clang tidy build
     - os: linux
       env: CLANG_TIDY
@@ -138,5 +141,7 @@ matrix:
         - make tidy
       # Overrides `before_script`, no need to run tests
       before_script:
+        - true
       # Overrides `script` to disable publishing
       script:
+        - true


### PR DESCRIPTION
Something regressed with how travis works which changed how we need to override stages. This should fix it, to avoid the odd `exit 86` errors that failed otherwise successful builds.