### PR TITLE
Add build matrix entries for Node 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,10 @@ matrix:
     - os: linux
       env: BUILDTYPE=release TOOLSET=cfi CXXFLAGS="-fsanitize=cfi -fvisibility=hidden" LDFLAGS="-fsanitize=cfi"
       node_js: 10
+    # linux publishable node v14/release
+    - os: linux
+      env: BUILDTYPE=release
+      node_js: 14
     # linux publishable node v12/release
     - os: linux
       env: BUILDTYPE=release
@@ -61,6 +65,11 @@ matrix:
       osx_image: xcode9.3
       env: BUILDTYPE=release
       node_js: 12
+    # osx publishable node v14/release
+    - os: osx
+      osx_image: xcode12.2
+      env: BUILDTYPE=release
+      node_js: 14
     # linux sanitizer build node v6/debug
     - os: linux
       env: BUILDTYPE=debug TOOLSET=asan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1
+
+* Add support for Node 14
+
 ## 0.5.0
 
 * Add `direct_hit_polygon` option to allow queries only allow polygons that contain the query point but still allow points and line segments that are within `radius` distance.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtquery",
-  "version": "0.5.0",
+  "version": "0.5.0-node14",
   "description": "Get features from Mapbox Vector Tiles from a lng/lat query point",
   "url": "http://github.com/mapbox/vtquery",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtquery",
-  "version": "0.5.0-node14",
+  "version": "0.5.1",
   "description": "Get features from Mapbox Vector Tiles from a lng/lat query point",
   "url": "http://github.com/mapbox/vtquery",
   "main": "./lib/index.js",


### PR DESCRIPTION
This PR adds `release` build workers for Node 14 to the Travis build matrix. It doesn't change/remove any of the others (so 10 is still there and is still the one used for `debug` builds, etc.), but will plan to leave that alone for the moment for backwards compatibility reasons, pending possibly re-review if/when #120 lands. It also makes no changes to actual code.

For the moment this branch adds a semver version suffix. Post-merge, I'll plan to cut a new patch release, with an accompanying `[publish binary]` commit in master.